### PR TITLE
Add build and deployment workflows

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,0 +1,57 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      main
+
+jobs:
+  build:
+    if: ${{ github.repository_owner == 'cosmicds' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.17.1'
+
+      - name: Yarn install
+        run: yarn install
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Build
+        run: yarn build
+
+          # - name: BrowserStack env setup
+          #   uses: browserstack/github-actions/setup-env@master
+          #   with:
+          #     username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          #     access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+
+          # - name: BrowserStack local tunnel setup
+          #   uses: browserstack/github-actions/setup-local@master
+          #   with:
+          #     local-testing: start
+          #     local-identifier: random
+
+          # - name: Run BrowserStack tests
+          #   run: |
+          #     set -xeuo pipefail
+          #     yarn serve &
+          #     sleep 10
+          #     yarn test-bslocal -e default,firefox,edge,safari -o reports
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: dist
+          ssh-key: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Build
+
+on:
+  pull_request_target:
+    branches:
+      main
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+    
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.17.1'
+
+      - name: Yarn install
+        run: yarn install
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Build
+        run: yarn build
+
+          # - name: BrowserStack env setup
+          #   uses: browserstack/github-actions/setup-env@master
+          #   with:
+          #     username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+          #     access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+
+          # - name: 'BrowserStack local tunnel setup'
+          #   uses: browserstack/github-actions/setup-local@master
+          #   with:
+          #     local-testing: start
+          #     local-identifier: random
+
+          # - name: Run BrowserStack tests
+          #   run: |
+          #     set -xeuo pipefail
+          #     yarn serve &
+          #     sleep 10
+          #     yarn test-bslocal -e default,firefox,edge,safari -o reports
+
+          # - name: 'BrowserStackLocal Stop'  # Terminating the BrowserStackLocal tunnel connection
+          #   uses: browserstack/github-actions/setup-local@master
+          #   with:
+          #     local-testing: stop


### PR DESCRIPTION
This PR adds our standard build and deployment workflows. We obviously don't have BrowserStack testing yet, but when we do we can just uncomment the relevant lines to add that in.