### PR TITLE
Check if draft before deploying

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -49,8 +49,15 @@ jobs:
           #     sleep 10
           #     yarn test-bslocal -e default,firefox,edge,safari -o reports
 
+      - name: Check for draft flag
+        uses: sergeysova/jq-action@v2
+        id: draft
+        with:
+          cmd: cat package.json | jq -r '.draft // false'
+
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
+        if: ${{ steps.draft.outputs.value }} == 'true'
         with:
           branch: gh-pages
           folder: dist


### PR DESCRIPTION
This PR updates the deployment workflow to not deploy the story if it's marked as a draft.

With the way things are set up, it's not easy to test that the CI workflow runs correctly until we merge, so if there are any needed tweaks I can handle them after.