### PR TITLE
Fix issue with annotation at certain zooms

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1195,7 +1195,7 @@ import { getTimezoneOffset, formatInTimeZone } from "date-fns-tz";
 import tzlookup from "tz-lookup";
 import { v4 } from "uuid";
 
-import { drawPlanets, drawSkyOverlays, makeAltAzGridText, layerManagerDraw, updateViewParameters, renderOneFrame } from "./wwt-hacks";
+import { drawPlanets, drawSkyOverlays, getScreenPosForCoordinates, makeAltAzGridText, layerManagerDraw, updateViewParameters, renderOneFrame } from "./wwt-hacks";
 
 type SheetType = "text" | "video" | null;
 type LearnerPath = "Location" | "Clouds" | "Learn";
@@ -1769,6 +1769,7 @@ export default defineComponent({
         drawPlanets(renderContext, opacity, this.currentFractionEclipsed);
       };
 
+
       /* eslint-disable @typescript-eslint/no-var-requires */
       Planets['_planetTextures'][0] = Texture.fromUrl(require("./assets/2023-09-19-SDO-Sun.png"));
       this.setForegroundImageByName("Digitized Sky Survey (Color)");
@@ -2128,8 +2129,8 @@ export default defineComponent({
 
       const sunPosition = Planets['_planetLocations'][0];
       const moonPosition = Planets['_planetLocations'][9];
-      const sunPoint = this.findScreenPointForRADec({ ra: sunPosition.RA * 15, dec: sunPosition.dec });
-      const moonPoint = this.findScreenPointForRADec({ ra: moonPosition.RA * 15, dec: moonPosition.dec });
+      const sunPoint = getScreenPosForCoordinates(this.wwtControl, sunPosition.RA, sunPosition.dec);
+      const moonPoint = getScreenPosForCoordinates(this.wwtControl, moonPosition.RA, moonPosition.dec);
       moonPoint.y = canvasHeight - moonPoint.y;
       sunPoint.x -= moonPoint.x;
       sunPoint.y = canvasHeight - sunPoint.y - moonPoint.y;
@@ -2991,11 +2992,7 @@ export default defineComponent({
     },
 
     wwtZoomDeg(_zoom: number) {
-      try {
-        this.removeAnnotations();
-      } finally {
-        this.updateIntersection();
-      }
+      this.updateIntersection();
     },
 
     useRegularMoon(_show: boolean) {

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2138,7 +2138,7 @@ export default defineComponent({
       const distanceToMoon = CAAMoon.radiusVector(jd);
       const distanceToSun = 149_597_871;
 
-      const rMoon = 1740;  // radius of the moon in km
+      const rMoon = 1737.4;  // radius of the moon in km
       const rSun = 696_340;
       const thetaMoon = Math.atan2(rMoon, distanceToMoon);
       const thetaSun = Math.atan2(rSun, distanceToSun);
@@ -2157,8 +2157,9 @@ export default defineComponent({
         return;
       }
 
-      const moonInsideSun = sunMoonDistance < rSunPx - rMoonPx;
-      const sunInsideMoon = sunMoonDistance < rMoonPx - rSunPx;
+      const sunMoonPointDist = Math.sqrt(sunPoint.x * sunPoint.x + sunPoint.y * sunPoint.y);
+      const moonInsideSun = sunMoonPointDist < rSunPx - rMoonPx;
+      const sunInsideMoon = sunMoonPointDist < rMoonPx - rSunPx;
 
       const dSq = sunMoonDistance * sunMoonDistance;
       const rMoonSq = rMoonPx * rMoonPx;
@@ -2224,8 +2225,9 @@ export default defineComponent({
           // m is the slope of the line joining the moon and the sun
           // mPerp is the slope of a line perpendicular to the line joining the moon and the sun
           // yInt is the y-intercept of a line passing through the two points of intersection
-          const mPerp = -sunPoint.x / (sunPoint.y + 1e-5);
-          const yInt = (sunPoint.x * sunPoint.x + sunPoint.y * sunPoint.y - (rSunPx * rSunPx - rMoonPx * rMoonPx)) / (2 * (sunPoint.y + 1e-5));
+          const epsilon = 1e-5;
+          const mPerp = -sunPoint.x / (sunPoint.y + epsilon);
+          const yInt = (sunPoint.x * sunPoint.x + sunPoint.y * sunPoint.y - (rSunPx * rSunPx - rMoonPx * rMoonPx)) / (2 * (sunPoint.y + epsilon));
 
           // Find the x-coordinates of the edge points of the moon-sun intersection
           const a = (1 + mPerp * mPerp);
@@ -2989,7 +2991,11 @@ export default defineComponent({
     },
 
     wwtZoomDeg(_zoom: number) {
-      this.updateIntersection();
+      try {
+        this.removeAnnotations();
+      } finally {
+        this.updateIntersection();
+      }
     },
 
     useRegularMoon(_show: boolean) {

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2149,8 +2149,7 @@ export default defineComponent({
       const rSunPx = 6 * thetaSun * canvasHeight / (this.wwtZoomDeg * D2R);
 
       const points: { x: number; y: number }[] = [];
-      const sunMoonAngle = this.greatCircleDistance(sunPosition, moonPosition);
-      const sunMoonDistance = 6 * sunMoonAngle * canvasHeight / (this.wwtZoomDeg * D2R);
+      const sunMoonDistance = Math.sqrt(sunPoint.x * sunPoint.x + sunPoint.y * sunPoint.y);
 
       // If there's no sun/moon intersection, no need to continue
       if (sunMoonDistance > rMoonPx + rSunPx) {
@@ -2158,9 +2157,8 @@ export default defineComponent({
         return;
       }
 
-      const sunMoonPointDist = Math.sqrt(sunPoint.x * sunPoint.x + sunPoint.y * sunPoint.y);
-      const moonInsideSun = sunMoonPointDist < rSunPx - rMoonPx;
-      const sunInsideMoon = sunMoonPointDist < rMoonPx - rSunPx;
+      const moonInsideSun = sunMoonDistance < rSunPx - rMoonPx;
+      const sunInsideMoon = sunMoonDistance < rMoonPx - rSunPx;
 
       const dSq = sunMoonDistance * sunMoonDistance;
       const rMoonSq = rMoonPx * rMoonPx;


### PR DESCRIPTION
This PR aims to resolve #19. The root of the problem is that whether or not the Sun was entirely inside the Moon depended on the screen resolution - basically, a small sliver of the Sun not covered by the Moon would be lost at low zoom due to screen resolution. This, combined with the fact that we'd already changed the Sun-Moon distance calculation to use a more precise method meant that we were trying to solve a screen-space describing the intersection of the circles, when no such intersection existed.

The solution here is to essentially free ourselves of some of the resolution-based issues by using the fraction pixel values where the sun and moon centers "should" be. This should keep everything in agreement and allow us to "know" that the Sun isn't completely covered by the Moon, even when the resolution of the annotation on the screen says otherwise.