### PR TITLE
Use correct initial Moon sprite

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1774,6 +1774,10 @@ export default defineComponent({
       this.setForegroundImageByName("Digitized Sky Survey (Color)");
       // this.setBackgroundImageByName("Black Sky Background");
       this.setForegroundOpacity(100);
+
+      // The initial Moon position is incorrect, and we use it to set the Moon sprite.
+      // Thus, we explicitly call for an update here.
+      this.moonPlace.updatePlanetLocation(this.wwtCurrentTime.getTime());
       this.updateMoonTexture(true);
 
       this.updateWWTLocation();


### PR DESCRIPTION
This PR solves #12. This was a tricky problem with a surprisingly simple solution.

Basically, the way that the `Place` tracking works is that, when we try to access the camera of a `Place` that's tracking an object, the getter looks up the location of that object and updates the camera appropriately. But until something actually calls that camera parameter getter, nothing actually gets updated. Since this doesn't happen until something changes in WWT, we were seeing the incorrect Moon sprite because the stored position is incorrect.

Once we know what's causing this, though, the solution is simple. We just explicitly tell the place to update the planet's location.