### PR TITLE
Keep sky opaque in Sun scope mode and only show cloud data on appropriate tab

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2871,11 +2871,16 @@ export default defineComponent({
       const astronomicalTwilight = 3 * _civilTwilight;
       
       const sunAlt = altRad;
-      this.skyOpacity = (1 + Math.atan(Math.PI * sunAlt / (-astronomicalTwilight))) / 2;
-      this.skyOpacity = this.skyOpacity * (1 - 0.75 * Math.pow(Math.E,-Math.pow((this.currentFractionEclipsed -1),2)/(0.001)));
+      let dssOpacity = 0;
+      if (this.viewerMode == 'SunScope') {
+        this.skyOpacity = 1;
+      } else {
+        this.skyOpacity = (1 + Math.atan(Math.PI * sunAlt / (-astronomicalTwilight))) / 2;
+        this.skyOpacity = this.skyOpacity * (1 - 0.75 * Math.pow(Math.E,-Math.pow((this.currentFractionEclipsed -1),2)/(0.001)));
+        dssOpacity = sunAlt > 0 ? 0 : 1 - (1 + Math.atan(Math.PI * sunAlt / (-astronomicalTwilight))) / 2;
+      }
       this.updateMoonTexture();
 
-      const dssOpacity = sunAlt > 0 ? 0 : 1 - (1 + Math.atan(Math.PI * sunAlt / (-astronomicalTwilight))) / 2;
       this.setForegroundOpacity(dssOpacity * 100);
     },
 
@@ -3100,6 +3105,7 @@ export default defineComponent({
         this.horizonOpacity = 0.6;
         this.startSolarScopeMode();
       }
+      this.updateSkyOpacityForSunAlt(this.sunPosition.altRad);
       this.updateMoonTexture();
     },
 

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -172,6 +172,7 @@
               :detect-location="false"
               :map-options="userSelectedMapOptions"
               :selected-circle-options="selectedCircleOptions"
+              :cloud-cover="learnerPath === 'Clouds'"
               class="leaflet-map"
               :geo-json-files="geojson"
             ></location-selector>


### PR DESCRIPTION
This PR keeps the sky opaque in Sun scope mode, while leaving the sky mode opacity transition unchanged.

Edit: Also updating this PR to only show cloud cover data on the appropriate tab. This part of the PR is a bit bolted on, but so is showing the cloud cover data in general, so I think that's unavoidable.