### PR TITLE
allow the basemap url to switch

### DIFF
--- a/src/LocationSelector.vue
+++ b/src/LocationSelector.vue
@@ -150,6 +150,7 @@ export default defineComponent({
       selectedPlaceCircle: null as L.CircleMarker | null,
       cloudCoverRectangles: L.layerGroup(),
       map: null as Map | null,
+      basemap: null as L.TileLayer | null
     };
   },
 
@@ -294,7 +295,8 @@ export default defineComponent({
       const map = L.map(mapContainer).setView(location, zoom);
       
       const options = { ...defaultMapOptions, ...this.mapOptions };
-      L.tileLayer(options.templateUrl, options).addTo(map);
+      this.basemap = L.tileLayer(options.templateUrl, options);
+      this.basemap.addTo(map);
 
       this.loadCloudCover().then(() => {
         this.updateCloudCover(this.cloudCover);
@@ -413,6 +415,17 @@ export default defineComponent({
         this.map.setView(this.latLng);
       }
     },
+    
+    mapOptions(newOptions: MapOptions, oldOptions: MapOptions) {
+      if (oldOptions === null || newOptions === null) {
+        return;
+      }
+      if (newOptions.templateUrl !== oldOptions.templateUrl) {
+        this.basemap?.setUrl(newOptions.templateUrl ?? defaultMapOptions.templateUrl);
+      }
+    },
+    
+    
     cloudCover(value: boolean) {
       this.updateCloudCover(value);
     },

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1423,7 +1423,7 @@ export default defineComponent({
     const initialView = {
       initialLocation: {
         latitudeDeg: 35,
-        longitudeDeg: -110
+        longitudeDeg: -100
       },
       initialZoom: 3.3
     };

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -170,7 +170,7 @@
               :initial-place="places.find(p => p.name === 'selectedLocation')"
               :place-circle-options="placeCircleOptions"
               :detect-location="false"
-              :map-options="userSelectedMapOptions"
+              :map-options="(learnerPath === 'Clouds') ? userSelectedMapOptions : initialMapOptions"
               :selected-circle-options="selectedCircleOptions"
               :cloud-cover="learnerPath === 'Clouds'"
               class="leaflet-map"
@@ -1492,6 +1492,10 @@ export default defineComponent({
         attribution: 'Maptiles by Stamen Design, under <a target="_blank" href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a target="_top" href="https://www.openstreetmap.org/#map=4/38.01/-95.84">OpenStreetMap</a>, under <a target="_top" href="http://creativecommons.org/licenses/by-sa/2.0">CC BY-SA 2.0</a>',
         ext: 'jpg',
         ...initialView
+      },
+      
+      initialMapOptions: {
+        ...(queryData ? { ...queryData, initialZoom: 5 } : initialView)
       },
 
       userSelectedMapOptions: {


### PR DESCRIPTION
The map will automatically change the basemap if the url in the `map-options` prop is changed. If no new url is passed, it will switch to the default map. 