### PR TITLE
improve location button permissions handling

### DIFF
--- a/src/GeolocationButton.vue
+++ b/src/GeolocationButton.vue
@@ -1,6 +1,6 @@
 <template>
   <span :id="`geolocation-wrapper+${id}`" class="geolocation">
-    <span v-if="showPermissions">Geolocation {{ permissions }} </span>
+    <p v-if="showPermissions">Geolocation {{ permissions }} </p>
     <v-btn 
       v-if="!hideButton"
       class="geolocation-button"
@@ -307,12 +307,20 @@ export default defineComponent({
     
     geolocation(val: GeolocationCoordinates) {
       if (this.emitLocation) {
+        // on Safari, the Permissions API is not supported, but still works
+        // make sure the frontend knows the permissions were "granted"
+        if (this.permissions != 'granted') {
+          this.permissions = 'granted';
+        }
         this.$emit('geolocation', val);
       }
     },
     
     geolocationError(val: GeolocationPositionError) {
       if (val) {
+        if (this.permissions != 'denied' && this.permissions != 'prompt') {
+          this.permissions = 'denied';
+        }
         this.$emit('error', val);
       }
     },

--- a/src/GeolocationButton.vue
+++ b/src/GeolocationButton.vue
@@ -20,7 +20,7 @@
     />
 
 
-    <span v-if="(showTextProgress || showProgressCircle) && loading && hideButton">
+    <span v-if="(showTextProgress || showProgressCircle) && loading && hideButton && permissionGranted">
       <v-progress-circular
         v-if="showProgressCircle"
         :size="progressCircleSize"
@@ -182,6 +182,7 @@ export default defineComponent({
       geolocation: null as GeolocationCoordinates | null,
       geolocationError: null as GeolocationPositionError | null,
       permissions: '',
+      permissionGranted: false,
       loading: false,
       loaded: false,
       emitLocation: false,
@@ -226,7 +227,7 @@ export default defineComponent({
     handlePermission(result: PermissionStatus) { 
       
       if (result.state === 'granted') {
-        
+        this.permissionGranted = true;
         this.debugmsg('Permission granted');
         
       } else if (result.state === 'prompt') {

--- a/src/GeolocationButton.vue
+++ b/src/GeolocationButton.vue
@@ -1,5 +1,6 @@
 <template>
   <span :id="`geolocation-wrapper+${id}`" class="geolocation">
+    <span v-if="showPermissions">Geolocation {{ permissions }} </span>
     <v-btn 
       v-if="!hideButton"
       class="geolocation-button"
@@ -158,6 +159,10 @@ export default defineComponent({
       default: 'black',
     },
     
+    showPermissions: {
+      type: Boolean,
+      default: false,
+    },
     
   },
 
@@ -173,7 +178,7 @@ export default defineComponent({
     return {
       geolocation: null as GeolocationCoordinates | null,
       geolocationError: null as GeolocationPositionError | null,
-      hasPermission: false,
+      permissions: '',
       loading: false,
       show: false,
     };
@@ -215,6 +220,7 @@ export default defineComponent({
         this.show = false;
         this.$emit('permissionDenied', true);
       }
+      this.permissions = result.state;
       console.log('Permission:', result.state);
       this.$emit('permission', result.state);
     },

--- a/src/GeolocationButton.vue
+++ b/src/GeolocationButton.vue
@@ -318,9 +318,6 @@ export default defineComponent({
     
     geolocationError(val: GeolocationPositionError) {
       if (val) {
-        if (this.permissions != 'denied' && this.permissions != 'prompt') {
-          this.permissions = 'denied';
-        }
         this.$emit('error', val);
       }
     },

--- a/src/GeolocationButton.vue
+++ b/src/GeolocationButton.vue
@@ -243,6 +243,15 @@ export default defineComponent({
       // Handle the error
       this.geolocationError = error;
       console.error('Geolocation error:', error);
+      // if the permission still is prompt, then
+      // then the browser has not been given permission
+      if (this.permissions === 'prompt') {
+        // modify the error.message to be more user friendly
+        this.geolocationError = {
+          code: 1,
+          message: `Location services were denied. Please ensure location services are enabled your browser in system settings`,
+        } as GeolocationPositionError;
+      }
       this.$emit('error', this.geolocationError);
     },
     

--- a/src/GeolocationButton.vue
+++ b/src/GeolocationButton.vue
@@ -252,7 +252,7 @@ export default defineComponent({
         const url = "https://www.lifewire.com/turn-on-mobile-location-services-4156232";
         this.geolocationError = {
           code: 1,
-          message: `Location access was denied. Please ensure location services are enabled for your browser in system settings. <a href="${url}" target="_blank" rel="noopener noreferrer">Help</a>`,
+          message: `Location access was denied. Please ensure location services are enabled for your browser in system settings. Note: this feature does not work on Safari on some iPhones. <a href="${url}" target="_blank" rel="noopener noreferrer">Help</a>`,
         } as GeolocationPositionError;
       } else {
         this.geolocationError = error;

--- a/src/GeolocationButton.vue
+++ b/src/GeolocationButton.vue
@@ -252,7 +252,7 @@ export default defineComponent({
         const url = "https://www.lifewire.com/turn-on-mobile-location-services-4156232";
         this.geolocationError = {
           code: 1,
-          message: `Location access was denied. Please ensure location services are enabled for your browser in system settings. Note: this feature does not work on Safari on some iPhones. <a href="${url}" target="_blank" rel="noopener noreferrer">Help</a>`,
+          message: `Location access was denied. Try enabling location services for your browser in system settings. (This feature might not work on Safari on some iPhones). <a href="${url}" target="_blank" rel="noopener noreferrer">Help</a>`,
         } as GeolocationPositionError;
       } else {
         this.geolocationError = error;

--- a/src/GeolocationButton.vue
+++ b/src/GeolocationButton.vue
@@ -191,6 +191,12 @@ export default defineComponent({
     
     // Check the Permissions API to see if the user has
     // granted the browser permission to access their location
+    if (!navigator.permissions) {
+      console.error('Permissions API not supported');
+      this.$emit('permission', 'denied');
+      this.show = false;
+      return;
+    }
     const query = navigator.permissions.query({ name: 'geolocation' });
     query.then((result) => {
       this.handlePermission(result);

--- a/src/GeolocationButton.vue
+++ b/src/GeolocationButton.vue
@@ -269,15 +269,18 @@ export default defineComponent({
       
       if (navigator.geolocation) {
         this.loading = showLoading;  
+        console.log('Getting location');
         navigator.geolocation.getCurrentPosition(
           (position) => {
             this.handlePosition(position);
             this.loading = false;
+            console.log('Got location');
           },
           
           (error) => {
             this.handleGeolocationError(error);
             this.loading = false;
+            console.log('Error getting location');
           },
           options
         );
@@ -309,7 +312,9 @@ export default defineComponent({
     },
     
     geolocationError(val: GeolocationPositionError) {
-      this.$emit('error', val);
+      if (val) {
+        this.$emit('error', val);
+      }
     },
     
   }

--- a/src/GeolocationButton.vue
+++ b/src/GeolocationButton.vue
@@ -31,6 +31,10 @@
       <span v-if="showTextProgress">Fetching location</span>
     </span>
 
+    <span v-if="(showTextProgress ) && loaded">
+      <span v-if="showTextProgress"><v-icon size="small" icon="mdi-check-circle-outline"></v-icon> Using your location</span>
+    </span>
+
     <span class="geolocation-text" v-if="showTextLabel && !useTextButton">
       <slot>
       {{ label }}
@@ -179,6 +183,7 @@ export default defineComponent({
       geolocationError: null as GeolocationPositionError | null,
       permissions: '',
       loading: false,
+      loaded: false,
       emitLocation: false,
       noPermissionsApi: false,
       counter: 0,
@@ -282,6 +287,11 @@ export default defineComponent({
             this.handlePosition(position);
             this.loading = false;
             this.debugmsg('Got location');
+            this.loaded = true;
+            setTimeout(() => {
+              this.loaded = false; 
+            }, 5000); // 5 seconds
+
           },
           
           (error) => {

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -667,7 +667,9 @@
               text: error.message,
               type: 'error',
             }); 
-            getMyLocation = true;
+            if (error.code === 1) {
+              geolocationPermission = 'denied';
+            }
             console.log(error);
             }"
             @permission="(p: PermissionState) => {

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -83,7 +83,7 @@
                   <p>
                     <strong>{{ touchscreen ? "Tap" : "Click" }}</strong> <font-awesome-icon icon="share-nodes" class="bullet-icon"/>: copy url for a location
                   </p>
-                  <p>
+                  <p v-if="getMyLocation">
                     <strong>{{ touchscreen ? "Tap" : "Click" }}</strong>
                     <font-awesome-icon icon="street-view" class="bullet-icon"/>:
                     view eclipse from <strong>My Location</strong> (Location services must be enabled on device)
@@ -554,7 +554,7 @@
                               size="lg" 
                             ></font-awesome-icon> to copy <strong>share-url</strong> for a specific location.
                       </li>
-                      <li>
+                      <li v-if="getMyLocation">
                         {{ touchscreen ? "Tap" : "Click" }} <font-awesome-icon
                               class="bullet-icon"
                               icon="street-view"

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -556,11 +556,12 @@
                             ></font-awesome-icon> to copy <strong>share-url</strong> for a specific location.
                       </li>
                       <li v-if="getMyLocation">
-                        {{ touchscreen ? "Tap" : "Click" }} <font-awesome-icon
-                              class="bullet-icon"
-                              icon="street-view"
-                              size="lg" 
-                            ></font-awesome-icon> to use the view my <strong>My Location</strong>. (Consult your device's user guide to enable location services.)                     
+                        {{ touchscreen ? "Tap" : "Click" }}
+                        <font-awesome-icon
+                          class="bullet-icon"
+                          icon="street-view"
+                          size="lg" 
+                        ></font-awesome-icon> to view from <strong>My Location</strong>. (If icon is grayed out, consult your device's user guide to enable location services. This feature works most reliably on Chrome and might not be available on every browser+operating system combination.)                    
                       </li>
                     </ul>
 
@@ -1977,7 +1978,9 @@ export default defineComponent({
     
     myLocationToolTip() {
       if (this.geolocationPermission === 'denied') {
-        return "Geolocation disabled. Check browser permissions for this site.";
+        return "Geolocation disabled. Check browser and site permissions and reload page.";
+      } else if (this.geolocationPermission === 'prompt') {
+        return "Click to enable location permissions";
       } else {
         return "Use my location";
       } 

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -626,10 +626,10 @@
           v-if="getMyLocation"
           id="my-location"
           fa-icon="street-view"
-          :color="accentColor"
-          :focus-color="accentColor"
+          :color="myLocationColor"
+          :focus-color="myLocationColor"
           :box-shadow="false"
-          tooltip-text="Use my location"
+          :tooltip-text="myLocationToolTip"
           :show-tooltip="!mobile"
           @update:modelValue="(value: boolean) => {
             if(value) {
@@ -667,16 +667,19 @@
               text: error.message,
               type: 'error',
             }); 
-            getMyLocation = false;
+            getMyLocation = true;
             console.log(error);
             }"
             @permission="(p: PermissionState) => {
+              geolocationPermission = p;
+              // we're always gonna show the button,
+              // just leaving this if we wanna change
               if (p == 'granted') {
                 getMyLocation = true;
               } else if (p == 'prompt') {
-                getMyLocation = false;
+                getMyLocation = true;
               } else {
-                getMyLocation = false;
+                getMyLocation = true;
               }
             }"
         ></geolocation-button>
@@ -1536,6 +1539,7 @@ export default defineComponent({
       showLocationSelector: false,
       getMyLocation: true,
       myLocation: null as LocationDeg | null,
+      geolocationPermission: '' as 'granted' | 'denied' | 'prompt',
       
       showWWTGuideSheet: false,
       
@@ -1965,6 +1969,35 @@ export default defineComponent({
       }
       return "Outside Range";
 
+    },
+    
+    myLocationToolTip() {
+      if (this.geolocationPermission === 'denied') {
+        return "Geolocation disabled. Check your browser settings.";
+      } else {
+        return "Use my location";
+      } 
+    },
+    
+    myLocationColor() {
+      if (this.myLocation) {
+        // check if location = myLocation. if not fade the color a bit.
+        if (this.locationDeg.latitudeDeg === this.myLocation.latitudeDeg && this.locationDeg.longitudeDeg === this.myLocation.longitudeDeg) {
+          return "limegreen";
+        } else {
+          return "green";
+        }
+        
+      } else {
+        
+        if (this.geolocationPermission === 'denied') {
+          return "grey";
+        } else if (this.geolocationPermission === 'granted') {
+          return this.accentColor;
+        } else {
+          return this.accentColor;
+        }
+      }
     },
 
     ready(): boolean {

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -648,6 +648,7 @@
       </div>
       <div id="location-progress" :class="[!showGuidedContent ?'budge' : '']">
         <geolocation-button
+          show-permissions
           :color="accentColor"
           hide-button
           show-progress-circle
@@ -1994,7 +1995,7 @@ export default defineComponent({
     },
     
     myLocationColor() {
-      
+      console.log(this.geolocationPermission);
       if (this.geolocationPermission === 'denied') {
         return "grey";
       }

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -673,7 +673,7 @@
               if (p == 'granted') {
                 getMyLocation = true;
               } else if (p == 'prompt') {
-                getMyLocation = true;
+                getMyLocation = false;
               } else {
                 getMyLocation = false;
               }

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -622,6 +622,7 @@
           faSize="1x"
         ></icon-button>
         <icon-button
+          v-if="getMyLocation"
           id="my-location"
           fa-icon="street-view"
           :color="accentColor"
@@ -646,12 +647,8 @@
       <div id="location-progress" :class="[!showGuidedContent ?'budge' : '']">
         <geolocation-button
           :color="accentColor"
-          :show-text-progress = "true"
-          :hide-text = "true"
-          :showCoords = "false"
-          :hide-button = "true"
-          :requirePermission = "false"
-          :hasPermission = "true"
+          show-text-progress
+          hide-button
           ref="geolocation"
           @geolocation="(loc: GeolocationCoordinates) => { 
             myLocation = {
@@ -672,7 +669,16 @@
             getMyLocation = false;
             console.log(error);
             }"
-        />
+            @permission="(p: PermissionState) => {
+              if (p == 'granted') {
+                getMyLocation = true;
+              } else if (p == 'prompt') {
+                getMyLocation = true;
+              } else {
+                getMyLocation = false;
+              }
+            }"
+        ></geolocation-button>
       </div>
       
       <!-- <div id="mobile-zoom-control"> -->
@@ -1527,9 +1533,9 @@ export default defineComponent({
       showTextTooltip: false,
       showMapSelector: false,
       showLocationSelector: false,
-      getMyLocation: false,
+      getMyLocation: true,
       myLocation: null as LocationDeg | null,
-
+      
       showWWTGuideSheet: false,
       
       selectionProximity: 4,

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -649,6 +649,7 @@
       <div id="location-progress" :class="[!showGuidedContent ?'budge' : '']">
         <geolocation-button
           :color="accentColor"
+          :show-text-progress = "true"
           hide-button
           show-progress-circle
           ref="geolocation"

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -624,6 +624,7 @@
         ></icon-button>
         <icon-button
           v-if="getMyLocation"
+          class="geolocation-button"
           id="my-location"
           fa-icon="street-view"
           :color="myLocationColor"
@@ -648,8 +649,8 @@
       <div id="location-progress" :class="[!showGuidedContent ?'budge' : '']">
         <geolocation-button
           :color="accentColor"
-          show-text-progress
           hide-button
+          show-progress-circle
           ref="geolocation"
           @geolocation="(loc: GeolocationCoordinates) => { 
             myLocation = {
@@ -1268,7 +1269,7 @@
     </v-dialog>
 
   <notifications group="copy-url" position="center top" classes="url-notification"/>
-  <notifications group="geolocation-error" position="center top" />
+  <notifications dangerouslySetInnerHtml group="geolocation-error" position="center top" />
   </div>
 </v-app>
 </template>
@@ -1973,6 +1974,17 @@ export default defineComponent({
 
     },
     
+    myLocationIcon() {
+      if (this.geolocationPermission === 'denied') {
+        return "mdi-map-marker-remove-variant";
+      } else if (this.geolocationPermission === 'prompt') {
+        return "mdi-crosshairs";
+      } else if (this.geolocationPermission === 'granted') {
+        return "mdi-crosshairs-gps";
+      }
+      return "mdi-crosshairs-question";
+    },
+    
     myLocationToolTip() {
       if (this.geolocationPermission === 'denied') {
         return "Geolocation disabled. Check browser permissions for this site.";
@@ -1982,24 +1994,32 @@ export default defineComponent({
     },
     
     myLocationColor() {
-      if (this.myLocation) {
-        // check if location = myLocation. if not fade the color a bit.
-        if (this.locationDeg.latitudeDeg === this.myLocation.latitudeDeg && this.locationDeg.longitudeDeg === this.myLocation.longitudeDeg) {
-          return "limegreen";
-        } else {
-          return "green";
-        }
+      
+      if (this.geolocationPermission === 'denied') {
+        return "grey";
+      }
+      
+      if (this.geolocationPermission === 'prompt') {
+        return "grey";
+      }
+      
+      if (this.geolocationPermission === 'granted') {
         
-      } else {
-        
-        if (this.geolocationPermission === 'denied') {
-          return "grey";
-        } else if (this.geolocationPermission === 'granted') {
-          return this.accentColor;
-        } else {
-          return this.accentColor;
+        if (this.myLocation) {
+          // check if location = myLocation. if not fade the color a bit.
+          if (
+            this.locationDeg.latitudeDeg === this.myLocation.latitudeDeg && this.locationDeg.longitudeDeg === this.myLocation.longitudeDeg
+          ) {
+            return "limegreen";
+          } else {
+            return "green";
+          }
         }
       }
+      
+      return this.accentColor;
+      
+      
     },
 
     ready(): boolean {
@@ -3381,7 +3401,9 @@ body {
     user-select: none;
   }
 
-  
+  #my-location-button {
+    border-width: 2px;
+  }
 }
 
 
@@ -3533,6 +3555,9 @@ body {
   .icon-wrapper {
     padding-inline: calc(0.3 * var(--default-line-height));
     padding-block: calc(0.4 * var(--default-line-height));
+  }
+  
+  .icon-wrapper:not(#my-location-button) {
     border: 2px solid var(--accent-color);
   }
 }

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1530,7 +1530,7 @@ export default defineComponent({
       uuid,
       responseOptOut: responseOptOut as boolean | null,
 
-      showSplashScreen: true,
+      showSplashScreen: false,
       backgroundImagesets: [] as BackgroundImageset[],
       sheet: null as SheetType,
       layersLoaded: false,

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2011,9 +2011,9 @@ export default defineComponent({
           if (
             this.locationDeg.latitudeDeg === this.myLocation.latitudeDeg && this.locationDeg.longitudeDeg === this.myLocation.longitudeDeg
           ) {
-            return "limegreen";
+            return this.accentColor;
           } else {
-            return "green";
+            return this.accentColor;
           }
         }
       }

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -544,7 +544,8 @@
                           
                     <v-divider thickness="2px" class="solid-divider"></v-divider>
 
-                    <h4 class="user-guide-header">Location Options:</h4>
+                    <h4 v-if="getMyLocation" class="user-guide-header">Location Options:</h4>
+                    <h4 v-else class="user-guide-header">Share location</h4>
                     <p  class="mb-3">(See top-left of the screen)</p>
                     <ul class="text-list">
                       <li>

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1973,7 +1973,7 @@ export default defineComponent({
     
     myLocationToolTip() {
       if (this.geolocationPermission === 'denied') {
-        return "Geolocation disabled. Check your browser settings.";
+        return "Geolocation disabled. Check browser permissions for this site.";
       } else {
         return "Use my location";
       } 

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -648,7 +648,6 @@
       </div>
       <div id="location-progress" :class="[!showGuidedContent ?'budge' : '']">
         <geolocation-button
-          show-permissions
           :color="accentColor"
           hide-button
           show-progress-circle
@@ -1973,17 +1972,6 @@ export default defineComponent({
       }
       return "Outside Range";
 
-    },
-    
-    myLocationIcon() {
-      if (this.geolocationPermission === 'denied') {
-        return "mdi-map-marker-remove-variant";
-      } else if (this.geolocationPermission === 'prompt') {
-        return "mdi-crosshairs";
-      } else if (this.geolocationPermission === 'granted') {
-        return "mdi-crosshairs-gps";
-      }
-      return "mdi-crosshairs-question";
     },
     
     myLocationToolTip() {


### PR DESCRIPTION
Improves the handling of permissions per #42 for the Geolocation Button, but internally and provides an emit for handling that in the template. It no longer has an emit to "ask for permissions" as there is nothing the parent can do. Asking permission is initiated using `navigator.geolocation.getCurrentPosition`. This is currently setup to check for the permissions and broadcast that to the parent. It will hide the button if it permissions aren't already granted and won't try to ask