### PR TITLE
Lots of UI updates

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -477,7 +477,7 @@
                           true-icon="mdi-white-balance-sunny"
                         >
                         </v-switch>
-                        <span class="user-guide-emphasis"> Track Sun:</span> Always keep camera centered on Sun.
+                        <span class="user-guide-emphasis"> Track Sun:</span> Camera follows the Sun.
                       </li>
                       <li class="switch-bullets mb-5">
                         <v-switch
@@ -491,7 +491,7 @@
                           false-icon="mdi-image"
                         >
                         </v-switch>
-                        <span class="user-guide-emphasis"> Don't Track Sun:</span> In Horizon View, show motion of Sun (and Moon) against the sky.
+                        <span class="user-guide-emphasis"> Don't Track Sun:</span> Camera stays fixed and shows motion of Sun (and Moon) against the sky.
                       </li>
                     </ul>
 
@@ -942,7 +942,7 @@
                 >
                 </v-switch>
             </template>
-            {{ toggleTrackSun ? "Don't Track Sun" : 'Center on Sun' }}
+            {{ toggleTrackSun ? "Don't Track Sun" : 'Track Sun' }}
           </hover-tooltip>
         </div>
       </div>

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -398,7 +398,7 @@
                       style="min-height: 120px;"
                   >                   
                     <h4 class="user-guide-header">Time Controls:</h4>
-                    <p  class="mb-3">(See bottom-left of the screen)</p>
+                    <p  class="mb-3">(Bottom-left of the screen)</p>
                     <ul class="text-list">
                       <li>
                         {{ touchscreen ? "Tap" : "Click" }} <font-awesome-icon
@@ -441,18 +441,18 @@
                         to reset time, view, and speed. 
                       </li>
                       <li>
-                        You can also control time by dragging <v-icon
+                        Drag <v-icon
                           class="bullet-icon"
                           icon="mdi-circle"
                           size="medium" 
-                        ></v-icon> along the slider.
+                        ></v-icon> along the slider to move to any time.
                       </li>
                     </ul>
 
                     <v-divider thickness="2px" class="solid-divider"></v-divider>
                     
                     <h4 class="user-guide-header">Viewing Mode:</h4>
-                    <p  class="mb-3">(See upper-right of the screen)</p>
+                    <p  class="mb-3">(Upper-right of the screen)</p>
                     <ul class="text-list">
                       <li class="mb-2">
                         The <span 
@@ -512,13 +512,13 @@
                     <v-divider thickness="2px" class="solid-divider"></v-divider>
                     
                     <h4 class="user-guide-header">Display Options:</h4>
-                    <p  class="mb-3">(See bottom-right of the screen)</p>
+                    <p  class="mb-3">(Bottom-right of the screen)</p>
                     <ul class="text-list">
                       <li>
                         <span class="user-guide-emphasis-white">Sky Grid:</span> Display altitude/azimuth grid with cardinal directions.
                       </li>
                       <li>
-                        <span class="user-guide-emphasis-white">Horizon:</span> Display a virtual "ground" that delineates where the Sun rises and sets.                     
+                        <span class="user-guide-emphasis-white">Horizon/Daytime Sky:</span> Display a virtual "ground" that delineates where the Sun rises and sets. Show a blue sky when the Sun is above the horizon.                     
                       </li>
                       <li>
                         <span class="user-guide-emphasis-white">Visible Moon:</span> Solar Eclipses occur during a New Moon, when the Moon is not normally visible in the sky. This option makes it easier to see the Moon against the sky.                     
@@ -531,7 +531,7 @@
                     <v-divider thickness="2px" class="solid-divider"></v-divider>
 
                     <h4 class="user-guide-header">Location Options:</h4>
-                    <p  class="mb-3">(See top-left of the screen)</p>
+                    <p  class="mb-3">(Top-left of the screen)</p>
                     <ul class="text-list">
                       <li>
                         {{ touchscreen ? "Tap" : "Click" }} <font-awesome-icon
@@ -999,7 +999,7 @@
               :color="accentColor"
               v-model="showHorizon"
               @keyup.enter="showHorizon = !showHorizon"
-              label="Horizon"
+              label="Horizon/Daytime Sky"
               hide-details
             />
             <v-checkbox

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -459,7 +459,14 @@
                         style="color: blue; background-color: white;
                         padding-inline: 0.7em;
                         border-radius: 20px;
-                        font-weight: bold ">selected location</span> and <span 
+                        font-weight: bold ">selected location</span>   
+                        <span 
+                        v-if="mobile"
+                        style="color: blue; background-color: white;
+                        padding-inline: 0.7em;
+                        border-radius: 20px;
+                        font-weight: bold ">historical cloud cover</span>  
+                        and <span 
                         style="color: blue; background-color: white;
                         padding-inline: 0.7em;
                         border-radius: 20px;

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -3242,12 +3242,11 @@ export default defineComponent({
 
     toggleTrackSun(val: boolean) {
       if (val) {
+        this.trackSun();
         if(this.sunOffset === null) {
           this.sunCenteredTracking = true;
-          this.trackSun();
           return;
         } else {
-          this.trackSunOffset();
           return;
         }
       } else {

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1894,7 +1894,7 @@ export default defineComponent({
     
     selectedLocaledTimeDateString() {
       if (this.smallSize) {
-        return formatInTimeZone(this.dateTime, this.selectedTimezone, 'MM/dd, HH:mm:ss (zzz)');
+        return formatInTimeZone(this.dateTime, this.selectedTimezone, 'MM/dd, HH:mm');
       } else {
         return formatInTimeZone(this.dateTime, this.selectedTimezone, 'MM/dd/yyyy HH:mm:ss (zzz)');
       }
@@ -1913,7 +1913,7 @@ export default defineComponent({
     
     selectedLocationCloudCoverString():string {
       if (this.selectedLocationCloudCover !== null) {
-        return `Hist. Cloud Cover: ${(this.selectedLocationCloudCover * 100).toFixed(0)}%`;
+        return `Hist Cld Cvr: ${(this.selectedLocationCloudCover * 100).toFixed(0)}%`;
       }
       return "Outside Range";
 
@@ -4684,6 +4684,18 @@ video, #info-video {
     justify-content: flex-end;
     flex-wrap: column;
     gap:5px;
+
+    @media (max-width: 700px) {
+      .v-chip.v-chip--density-default {
+        height: var(--default-line-height);
+        padding-inline: 0.8rem;
+        padding-block: 0.8rem;
+      }
+
+      .v-chip__content {
+        font-size: calc(0.8 * var(--default-font-size));
+      }
+    }
 
   }
 

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -465,20 +465,6 @@
                         border-radius: 20px;
                         font-weight: bold ">date/time</span> are displayed under the map.
                       </li>
-                      <li class="switch-bullets mb-3">
-                        <v-switch
-                          class="display-only-switch"
-                          v-model="displaySwitchOn"
-                          density="compact"
-                          hide-details
-                          disabled
-                          :ripple="false"
-                          :color="accentColor"
-                          true-icon="mdi-image-filter-hdr"
-                        >
-                        </v-switch>
-                        <span class="user-guide-emphasis"> Horizon:</span> Display motion of Sun and Moon as they travel through the sky relative to the ground.
-                      </li>
                       <li class="switch-bullets">
                         <v-switch
                           class="display-only-switch"

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -324,7 +324,20 @@
                     <details>
                       <summary>Where can I learn more?</summary>
                       <p>
-                        Check out <a href="https://science.nasa.gov/eclipses/future-eclipses/eclipse-2024/where-when/" target="_blank" rel="noopener noreferrer">NASA's website</a> about the October annular eclipse and Fiske Planetarium's <a href="https://www.colorado.edu/fiske/projects/science-through-shadows" target="_blank" rel="noopener noreferrer">Science Through Shadows</a> videos.
+                        Check out
+                        <ul>
+                          <li><a href="https://science.nasa.gov/eclipses/future-eclipses/eclipse-2024/where-when/" target="_blank" rel="noopener noreferrer">NASA's website</a> about the April eclipse
+                          </li>
+                          <li>
+                            Infiniscope's <a href="https://infiniscope.org/lesson/21" target="_blank" rel="noopener noreferrer">Kingdom in Peril</a> lesson on eclipses (available in English and Spanish)
+                          </li>
+                          <li>
+                            <a href="https://EclipseSoundscapes.org" target="_blank" rel="noopener noreferrer">Eclipse Soundscapes</a> citizen science project
+                          </li>
+                          <li>
+                            Fiske Planetarium's <a href="https://www.colorado.edu/fiske/projects/science-through-shadows" target="_blank" rel="noopener noreferrer">Science Through Shadows</a> videos
+                          </li>
+                        </ul>
                       </p>
                     </details>
                   </div>
@@ -4810,7 +4823,7 @@ video, #info-video {
 a {
     text-decoration: none;
     font-weight: bold;
-    color: #589eef; // lighter variant of sky color
+    color: #6facf1; // lighter variant of sky color
     pointer-events: auto;
   }
 


### PR DESCRIPTION
### Big stuff (in the commit called "Coordinate sun tracking & centering UI")
With Jon's #41 update to allow tracking off center, we needed to coordinate the switches and offer the user a way to center back on the Sun. It ended up being way more complicated than I thought it would be, and I'm not sure my changes are bulletproof, but everything seems to behave how I intended it to. It would be good if someone could please check and make sure everything makes sense. I had to delete/disable some things where I was not 100% sure what they were meant to do, and it's possible I left in things or added things that are not really necessary. This is what I intended:
- If user is tracking Sun (`toggleTrackSun = true`), we need to make sure that tracking is active whether we are centered on the Sun (`trackSun`) or not centered (`trackSunOffset`).
- If user is not tracking Sun, we should not be doing either `trackSun` or `trackSunOffset`
- If Sun is centered and tracking (`sunCenteredTracking = true`), disable but check the "Center Sun" box. (I disable it because it doesn't make sense to be able to uncheck the "Center Sun" box because it's not like we can pick a random point to send them to, now that centering & tracking are 2 separate things).
- If Sun is not centered or if we are not tracking the Sun, the Center Sun box is unchecked and can be checked to bring the sun back to center and begin tracking again.
- I added a thing called `activePointer` because while I was mousing down and panning around in WWT, the sun tracking toggle would automatically change itself to off, so I only try to set `trackingSun` if `activePointer = false`.

### Smaller stuff
- Remove SunScope mode (and always stay in Horizon Mode). Feedback is that it was confusing users.
- Remove corresponding documentation related to SunScope mode
- With #41, we can track without being centered, so documentation now just refers to "tracking Sun" rather than "center on sun"
- Make sure all 3 white chips fit across screen on mobile. (We disable the cloud cover chip on desktop because it appears prominently in the cloud info box anyway).
- Describe what the cloud cover chip is for in the documentation
- Link to other SciAct eclipse resources