### PR TITLE
Use MapBox for determining location text

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -29,6 +29,9 @@ jobs:
 
       - name: Build
         run: yarn build
+        env:
+          VUE_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+          VUE_APP_CDS_API_KEY: ${{ secrets.CDS_API_KEY }}
 
           # - name: BrowserStack env setup
           #   uses: browserstack/github-actions/setup-env@master

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -3096,7 +3096,7 @@ export default defineComponent({
     },
 
     async updateSelectedLocationText() {
-      const accessToken = process.env.MAPBOX_ACCESS_TOKEN;
+      const accessToken = process.env.VUE_APP_MAPBOX_ACCESS_TOKEN;
       const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${this.locationDeg.longitudeDeg},${this.locationDeg.latitudeDeg}.json?access_token=${accessToken}`;
       const mapBoxText = await fetch(url)
         .then(response => response.json())

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -918,17 +918,6 @@
   <div id="top-wwt-content">
       <div id="location-date-display">
         <v-chip 
-          :prepend-icon="smallSize ? `` : `mdi-map-marker-radius`"
-          variant="outlined"
-          size="small"
-          elevation="2"
-          :text="selectedLocationText"
-          @click="() => {
-            showGuidedContent = true; 
-            learnerPath = 'Location'
-            }"
-        > </v-chip>
-        <v-chip 
           :prepend-icon="smallSize ? `` : `mdi-clouds`"
           v-if="mobile"
           variant="outlined"
@@ -943,6 +932,17 @@
         elevation="2"
         :text="selectedLocaledTimeDateString"
       > </v-chip>
+      <v-chip 
+          :prepend-icon="smallSize ? `` : `mdi-map-marker-radius`"
+          variant="outlined"
+          size="small"
+          elevation="2"
+          :text="selectedLocationText"
+          @click="() => {
+            showGuidedContent = true; 
+            learnerPath = 'Location'
+            }"
+        > </v-chip>
       </div>
       <div id="top-switches">
         <div id="track-sun-switch"> 


### PR DESCRIPTION
This PR updates the selected location text to use MapBox. The previous lat/lon text is still used as a fallback in case we have some issue hitting the API.

Since the call to the MapBox API is necessarily asynchronous, I changed `selectedLocationText` to be part of the component data, and it's updated via an async method that gets called when the location is updated. The MapBox handling code looks kinda gnarly, but it's mostly just checking that the features that we expect to exist are actually there.