### PR TITLE
Updates to location text

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1349,6 +1349,10 @@ const OPT_OUT_KEY = "eclipse-mini-optout" as const;
 const USER_SELECTED_LOCATIONS_KEY = "user-selected-locations" as const;
 const PRESET_LOCATIONS_KEY = "preset-locations" as const;
 
+const RELEVANT_FEATURE_TYPES = ["postcode", "place", "region", "country"];
+const NA_COUNTRIES = ["United States", "Canada", "Mexico"];
+const NA_ABBREVIATIONS = ["US-", "CA-", "MX-"];
+
 import { dsvFormat } from "d3-dsv";
 import { eclipse } from "./eclipse_path";
 
@@ -1557,7 +1561,7 @@ export default defineComponent({
         longitudeRad: D2R * -104.1383333
       } as LocationRad,
       selectedLocation,
-      selectedLocationText: "",
+      selectedLocationText: "Nazas, DUR, Mexico",
       locationErrorMessage: "",
       
       syncDateTimeWithWWTCurrentTime: true,
@@ -1816,8 +1820,6 @@ export default defineComponent({
           longitudeDeg: R2D * pl.longitudeRad
         };
       });
-
-    this.updateSelectedLocationText();
 
   },
 
@@ -3117,29 +3119,33 @@ export default defineComponent({
     },
 
     mapboxLocationText(location: MapBoxFeatureCollection): string {
-      const relevantFeatureTypes = ["postcode", "place", "region", "country"];
-      const relevantFeatures = location.features.filter(feature => relevantFeatureTypes.some(type => feature.place_type.includes(type)));
+      const relevantFeatures = location.features.filter(feature => RELEVANT_FEATURE_TYPES.some(type => feature.place_type.includes(type)));
       const placeFeature = relevantFeatures.find(feature => feature.place_type.includes("place")) ?? (relevantFeatures.find(feature => feature.place_type.includes("postcode")) ?? null);
-      let text = placeFeature ? placeFeature.text : "";
+      const pieces: string[] = [];
+      if (placeFeature && placeFeature.text) {
+        pieces.push(placeFeature.text);
+      }
       const countryFeature = relevantFeatures.find(feature => feature.place_type.includes("country"));
       if (countryFeature) {
-        let countryText = countryFeature.text;
-        if (countryText === "United States") {
-          countryText = "USA";
+        let countryText: string | null = countryFeature.text;
+        if (NA_COUNTRIES.includes(countryText)) {
+          countryText = null;
           const regionFeature = relevantFeatures.find(feature => feature.place_type.includes("region"));
           if (regionFeature) {
             let stateCode = regionFeature.properties.short_code as string;
             if (stateCode) {
-              if (stateCode.startsWith("US-")) {
+              if (NA_ABBREVIATIONS.some(abbr => stateCode.startsWith(abbr))) {
                 stateCode = stateCode.substring(3);
               }
-              text = `${text}, ${stateCode}`;
+              pieces.push(stateCode);
             }
           }
         }
-        text = `${text}, ${countryText}`;
+        if (countryText) {
+          pieces.push(countryText);
+        }
       }
-      return text;
+      return pieces.join(", ");
     },
 
     async updateSelectedLocationText() {

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1561,7 +1561,7 @@ export default defineComponent({
         longitudeRad: D2R * -104.1383333
       } as LocationRad,
       selectedLocation,
-      selectedLocationText: "Nazas, DUR, Mexico",
+      selectedLocationText: "Nazas, DUR",
       locationErrorMessage: "",
       
       syncDateTimeWithWWTCurrentTime: true,


### PR DESCRIPTION
This PR builds off of #52 with a couple more updates:

* The initial location text is now hardcoded to "Nazas, DUR". This fixes a production issue that we were seeing with only the first MapBox request failing, and additionally saves us one MapBox request per use of the app.
* Since this is a North America-focused story, country text has been removed for the US, Canada, and Mexico. State/province text has also been added for Canada and Mexico.