### PR TITLE
Start playing WWT time when the intro dialog is closed

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -3190,8 +3190,11 @@ export default defineComponent({
     },
 
     inIntro(value: boolean) {
-      if (!value && !this.showSplashScreen && this.responseOptOut === null) {
-        this.showPrivacyDialog = true;
+      if (!value) {
+        this.playing = true;
+        if (!this.showSplashScreen && this.responseOptOut === null) {
+          this.showPrivacyDialog = true;
+        }
       }
     },
 

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1726,7 +1726,7 @@ export default defineComponent({
       activePointer: false,
       showControls: true,
       sunCenteredTracking: true,
-      showAltAzGrid: true,
+      showAltAzGrid: false,
       showHorizon: true,
       showTextSheet: false, 
       showEclipsePercentage: true, 
@@ -2977,7 +2977,7 @@ export default defineComponent({
     startHorizonMode() {
       // turn on local horizon mode
       this.wwtSettings.set_localHorizonMode(true);
-      this.showAltAzGrid = true;
+      this.showAltAzGrid = false;
       this.skyColor = this.skyColorLight;
       this.showHorizon = true; // automatically calls it's watcher and updates horizon
       this.horizonOpacity = 1;


### PR DESCRIPTION
This PR resolves #58 by setting WWT to play when the user closes the intro dialog (the one after the splash screen). This is handled in the listener for `inIntro` (which is the `v-model` flag for the intro dialog).