### PR TITLE
Add query parameter for hiding splash screen

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -80,7 +80,7 @@
                 </div> -->
                 
                 <div v-if="infoPage==1">
-                  <p v-if="!queryData">
+                  <p v-if="queryData.latitudeDeg == undefined || queryData.longitudeDeg == undefined">
                     <strong>{{ touchscreen ? "Tap" : "Click" }}</strong> <font-awesome-icon icon="play" class="bullet-icon"/> to "watch" the eclipse from the location marked by the red dot on the map, or <strong>drag</strong> the yellow dot along the bottom slider to change time.
                   </p>
                   <p v-if="queryData.latitudeDeg !== undefined && queryData.longitudeDeg !== undefined">

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -81,10 +81,10 @@
                 
                 <div v-if="infoPage==1">
                   <p v-if="queryData.latitudeDeg == undefined || queryData.longitudeDeg == undefined">
-                    <strong>{{ touchscreen ? "Tap" : "Click" }}</strong> <font-awesome-icon icon="play" class="bullet-icon"/> to "watch" the eclipse from the location marked by the red dot on the map, or <strong>drag</strong> the yellow dot along the bottom slider to change time.
+                    "Watch" the eclipse from the location marked by the red dot on the map, or <strong>drag</strong> the yellow dot along the bottom slider to change time.
                   </p>
                   <p v-if="queryData.latitudeDeg !== undefined && queryData.longitudeDeg !== undefined">
-                    <strong>{{ touchscreen ? "Tap" : "Click" }}</strong> <font-awesome-icon icon="play" size="lg" class="bullet-icon"/> to "watch" the eclipse from the location shared in your link.
+                    "Watch" the eclipse from the location shared in your link, or <strong>drag</strong> the yellow dot along the bottom slider to change time.
                   </p>
                   <p>
                     <strong>{{ touchscreen ? "Tap" : "Click" }}</strong> the map to select any <span v-if="queryData.latitudeDeg !== undefined && queryData.longitudeDeg !== undefined">other</span> location and view the eclipse from there.

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1536,9 +1536,15 @@ export default defineComponent({
 
     const selections = window.localStorage.getItem(USER_SELECTED_LOCATIONS_KEY);
     const userSelectedLocationsVisited: [number, number][] = selections ? (this.parseJSONString(selections) ?? []) : [];
-    const [latDeg, lonDeg] = [queryData.latitudeDeg, queryData.longitudeDeg];
-    if (latDeg !== undefined && lonDeg !== undefined) {
-      userSelectedLocationsVisited.push([latDeg, lonDeg]);
+    const [latitudeDeg, longitudeDeg] = [queryData.latitudeDeg, queryData.longitudeDeg];
+    
+    let initialMapOptions = initialView;
+    if (latitudeDeg !== undefined && longitudeDeg !== undefined) {
+      userSelectedLocationsVisited.push([latitudeDeg, longitudeDeg]);
+      initialMapOptions = {
+        initialLocation: { latitudeDeg, longitudeDeg },
+        initialZoom: 5
+      };
     }
 
     const presets = window.localStorage.getItem(PRESET_LOCATIONS_KEY);
@@ -1551,8 +1557,8 @@ export default defineComponent({
 
     const storedOptOut = window.localStorage.getItem(OPT_OUT_KEY);
     const responseOptOut = typeof storedOptOut === "string" ? storedOptOut === "true" : null;
-    const location: LocationRad = (latDeg !== undefined && lonDeg !== undefined) ?
-      { latitudeRad: D2R * latDeg, longitudeRad: D2R * lonDeg } :
+    const location: LocationRad = (latitudeDeg !== undefined && longitudeDeg !== undefined) ?
+      { latitudeRad: D2R * latitudeDeg, longitudeRad: D2R * longitudeDeg } :
       { latitudeRad: D2R * 25.2866667, longitudeRad: D2R * -104.1383333 };
     return {
       uuid,
@@ -1602,9 +1608,7 @@ export default defineComponent({
         ...initialView
       },
       
-      initialMapOptions: {
-        ...(queryData ? { ...queryData, initialZoom: 5 } : initialView)
-      },
+      initialMapOptions,
 
       userSelectedMapOptions: {
         // templateUrl: "https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png",
@@ -1741,7 +1745,7 @@ export default defineComponent({
         radius: 5
       },
 
-      learnerPath: (queryData ? "Clouds" : "Location") as LearnerPath,
+      learnerPath: "Location" as LearnerPath,
       
       playing: false,
       playingIntervalId: null as ReturnType<typeof setInterval> | null,

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1564,7 +1564,7 @@ export default defineComponent({
       uuid,
       responseOptOut: responseOptOut as boolean | null,
 
-      showSplashScreen: queryData.splash ?? true, // ACTION NEEDED make sure this is true before deploying
+      showSplashScreen: queryData.splash ?? true, 
       backgroundImagesets: [] as BackgroundImageset[],
       sheet: null as SheetType,
       layersLoaded: false,
@@ -1843,7 +1843,6 @@ export default defineComponent({
     }
     const splashQuery = searchParams.get("splash");
     queryData.splash = splashQuery !== "false";
-
   },
 
   created() {
@@ -1921,7 +1920,10 @@ export default defineComponent({
       this.updateMoonTexture(true);
 
       this.updateWWTLocation();
-      this.setClockSync(false); // set to false to pause
+      
+      this.setClockSync(!queryData.splash); // set to true if queryData.splash == false
+      this.playing = !queryData.splash;
+
       this.setClockRate(1); //
 
       this.playbackRate = 1;  //this.setplaybackRate('8 minutes per second'); // 500;


### PR DESCRIPTION
This PR adds a query parameter for hiding the splash screen as requested in #67. Using a query of `splash=false` (`False` is also accepted) will hide the splash screen.

@patudom Do we want this to hide the intro dialog as well? Currently it does - my thought is that, unless one is working on the intro dialog, it would also be nicer to skip that during development.