### PR TITLE
Record info time if window is still visible

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1997,7 +1997,7 @@ export default defineComponent({
         if (document.visibilityState === "hidden") {
           this.sendUpdateData();
         } else {
-          this.clearData();
+          this.resetData();
         }
       });
 
@@ -2844,11 +2844,13 @@ export default defineComponent({
       });
     },
 
-    clearData() {
+    resetData() {
       this.userSelectedLocations = [];
       this.cloudCoverSelectedLocations = [];
       this.infoTimeMs = 0;
-      this.appStartTimestamp = Date.now();
+      const now = Date.now();
+      this.appStartTimestamp = now;
+      this.infoStartTimestamp = this.showInfoSheet ? now : null;
     },
 
     sendUpdateData() {
@@ -2872,7 +2874,7 @@ export default defineComponent({
         }),
         keepalive: true,
       }).then(() => {
-        this.clearData();
+        this.resetData();
       });
     },
 

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2857,6 +2857,8 @@ export default defineComponent({
       if (this.responseOptOut) {
         return;
       }
+      const now = Date.now();
+      const infoTime = (this.showInfoSheet && this.infoStartTimestamp !== null) ? now - this.infoStartTimestamp : this.infoTimeMs;
       fetch(`${API_BASE_URL}/solar-eclipse-2024/data/${this.uuid}`, {
         method: "PATCH",
         headers: {
@@ -2870,7 +2872,7 @@ export default defineComponent({
           // eslint-disable-next-line @typescript-eslint/naming-convention
           cloud_cover_selected_locations: toRaw(this.cloudCoverSelectedLocations),
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          delta_info_time_ms: this.infoTimeMs, delta_app_time_ms: Date.now() - this.appStartTimestamp
+          delta_info_time_ms: infoTime, delta_app_time_ms: Date.now() - this.appStartTimestamp
         }),
         keepalive: true,
       }).then(() => {


### PR DESCRIPTION
This PR fixes a bug where the info time is not recorded properly if the user leaves the page/switches tabs while the info window is still open.