### PR TITLE
change v-text-field label after change

### DIFF
--- a/src/AdvancedWeatherView.vue
+++ b/src/AdvancedWeatherView.vue
@@ -11,12 +11,13 @@
         <define-term 
           no-click
           width="25ch"
+          :showFor="firstOpen ? 5 : 0"
           definition='<p class="intro">
           Click for more details about the cloud cover data, statistical terms, and the El Niño & La Niña weather patterns. 
         </p>'
           >
-          <template #term>
-            <v-btn style="font-size: 1em;" elevation="1" icon="mdi-help-circle" @click="explainerOpen = true"></v-btn>
+          <template v-slot:term="{props}">
+            <v-btn v-bind="props" style="font-size: 1em;" elevation="1" icon="mdi-help-circle" @click="explainerOpen = true" tabindex="0"></v-btn>
           </template>
         </define-term>
         <cloud-data-explainer
@@ -460,6 +461,7 @@ export default defineComponent({
   data() {
     const eps = 0.000001;
     return {
+      firstOpen: true,
       explainerOpen: false,
       statText,
       mapSubsets,
@@ -1197,6 +1199,7 @@ export default defineComponent({
       } else {
         console.log('closing AWV view');
         this.needToUpdate = true;
+        this.firstOpen = false;
         // this.displayData = false;
       }
     }, 

--- a/src/DefineTerm.vue
+++ b/src/DefineTerm.vue
@@ -2,23 +2,22 @@
 import { tooltip } from 'leaflet';
 <template>
   <v-tooltip 
+    v-model="tooltip"
     :width="width"
     :open-on-click="!noClick"
     :open-on-hover="true"
     :open-on-focus="true"
     >
     <template v-slot:activator="{props}" >
-      <div :class="['define-term-tooltip', inline ? 'inline' : '']" v-bind="props">
-        <slot name="term">
-          {{ term }}
+        <slot name="term" v-bind="props" tabindex="0" :props="props">
+          <span tabindex="0" :class="['define-term-tooltip', inline ? 'inline' : '']" v-bind="props" > {{  term }} </span>
         </slot>
-      </div>
     </template>
     
     <slot name="definition">
-    <div class="define-term-tooltip definition" v-html="definition">
-    </div>
-  </slot>
+      <div class="define-term-tooltip definition" v-html="definition">
+      </div>
+    </slot>
 
     </v-tooltip>
 </template>
@@ -54,8 +53,42 @@ export default defineComponent({
     noClick: {
       type: Boolean,
       default: false
+    },
+    showFor: {
+      type: Number,
+      default: 0,
+      validator: (value: number) => value >= 0
     }
-  }
+  },
+  
+  data() {
+    return {
+      tooltip: false
+    };
+  },
+  
+  mounted() {
+    if (this.showFor > 0) {
+      this.timedShow();
+    }
+  },
+  
+  methods: {
+    show() {
+      this.tooltip = true;
+    },
+    hide() {
+      this.tooltip = false;
+    },
+    
+    timedShow() {
+      this.show();
+      setTimeout(() => {
+        this.hide();
+      }, this.showFor * 1000);
+    }
+    
+  },
 });
 
 

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -705,7 +705,7 @@
               v-show="searchOpen"
               v-model="searchText"
               class="forward-geocoding-input"
-              label="Enter a location"
+              :label="locationJustUpdated ? 'Location Updated!' : 'Enter a location'"
               bg-color="black"
               density="compact"
               hide-details
@@ -1809,6 +1809,7 @@ export default defineComponent({
       searchText: null as string | null,
       searchResults: null as MapBoxFeatureCollection | null,
       searchErrorMessage: null as string | null,
+      locationJustUpdated: false,
 
       showMapTooltip: false,
       showTextTooltip: false,
@@ -3524,8 +3525,16 @@ export default defineComponent({
         }
       });
     },
+    
+    timedJustUpdatedLocation() {
+      this.locationJustUpdated = true;
+      setTimeout(() => {
+        this.locationJustUpdated = false;
+      }, 5000);
+    },
 
     setLocationFromFeature(feature: MapBoxFeature) {
+      this.timedJustUpdatedLocation();
       this.locationDeg = { longitudeDeg: feature.center[0], latitudeDeg: feature.center[1] };
       this.textForLocation(feature.center[0], feature.center[1]).then((text) => {
         this.selectedLocationText = text;

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1297,6 +1297,7 @@
                 location-strategy="connected"
                 persistent
                 no-click-animation
+                :retain-focus="false"
                 >
                 <template v-slot:activator="{ props }">
                   <icon-button

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1986,6 +1986,7 @@ export default defineComponent({
   mounted() {
     
     if (queryData.latitudeDeg !== undefined && queryData.longitudeDeg !== undefined) {
+      this.selectedTimezone = tzlookup(...[queryData.latitudeDeg, queryData.longitudeDeg]);
       this.updateSelectedLocationText();
     }
     this.createUserEntry();

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -704,8 +704,8 @@
             <v-text-field
               v-show="searchOpen"
               v-model="searchText"
-              class="forward-geocoding-input"
-              :label="locationJustUpdated ? 'Location Updated!' : 'Enter a location'"
+              :class="['forward-geocoding-input', locationJustUpdated ? 'geocode-success' : '']"
+              :label="locationJustUpdated ? 'Location Updated' : 'Enter a location'"
               bg-color="black"
               density="compact"
               hide-details
@@ -5527,6 +5527,11 @@ a {
   .v-text-field {
     min-width: 150px;
     width: min(200px, 20vw);
+  }
+  
+  .forward-geocoding-input.geocode-success label {
+    color: var(--accent-color);
+    opacity: 1;
   }
 
   #forward-geocoding-input-row {


### PR DESCRIPTION
This PR 

- temporarily changes the `v-text-field` label right after the location is changed so there is a clear indication when the text box is used. 
- fixes the AWV help icon so that it get's focus properly
- DefineTerm tooltip can now be displayed for a settable number of seconds when mounted (per request)
- The selectedTimezone needs to updated at mount so that it can be set by query parameters