### PR TITLE
Location tracking updates

### DIFF
--- a/src/AdvancedWeatherView.vue
+++ b/src/AdvancedWeatherView.vue
@@ -432,7 +432,7 @@ export default defineComponent({
     'define-term': DefineTerm,
   },
   
-  emits: ['update:modelValue','close', 'explainer-open', 'location'],
+  emits: ['update:modelValue','close', 'explainer-open', 'location', 'close'],
   
   props: {
     modelValue: {
@@ -586,7 +586,7 @@ export default defineComponent({
       set(value: boolean) {
         console.log('AdvancedWeatherView showValue set to', value);
         if (!value) {
-          this.$emit('location', this.location);
+          this.$emit('close', this.location);
         }
         this.$emit('update:modelValue', value);
       },
@@ -1262,6 +1262,9 @@ export default defineComponent({
       console.log('location', value);
       if (value.latitudeDeg === old.latitudeDeg && value.longitudeDeg === old.longitudeDeg) {
         return;
+      }
+      if (value !== this.defaultLocation) {
+        this.$emit('location', value);
       }
       this.updateLocationName();
       this.checkInBounds(value).then((inBounds) => {

--- a/src/AdvancedWeatherView.vue
+++ b/src/AdvancedWeatherView.vue
@@ -1263,7 +1263,11 @@ export default defineComponent({
       if (value.latitudeDeg === old.latitudeDeg && value.longitudeDeg === old.longitudeDeg) {
         return;
       }
-      if (value !== this.defaultLocation) {
+      if (
+        value.latitudeDeg !== this.defaultLocation.latitudeDeg
+        ||
+        value.longitudeDeg !== this.defaultLocation.longitudeDeg
+      ) {
         this.$emit('location', value);
       }
       this.updateLocationName();

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -3127,6 +3127,7 @@ export default defineComponent({
       this.weatherInfoTimeMs = 0;
       this.eclipseTimerTimeMs = 0;
       this.advancedWeatherSelectedCount = 0;
+      this.cloudCoverSelectedCount = 0;
       const now = Date.now();
       this.appStartTimestamp = now;
       this.infoStartTimestamp = this.showInfoSheet ? now : null;

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -713,6 +713,7 @@
     @location="(loc: LocationDeg) => {
       locationDeg = loc;
       updateLocationFromMap(loc);
+      advancedWeatherSelectedCount += 1;
     }"
     />
   
@@ -2051,6 +2052,7 @@ export default defineComponent({
       userSelectedLocations,
       cloudCoverSelectedLocations: [] as [number, number][],
       textSearchSelectedLocations: [] as [number, number][],
+      advancedWeatherSelectedCount: 0,
       eclipsePrediction: null as EclipseData<Date> | null,
       eclipseStart: 0 as number | null,
       eclipseMid: 0 as number | null,
@@ -3101,6 +3103,8 @@ export default defineComponent({
           text_search_selected_locations: toRaw(this.textSearchSelectedLocations),
           // eslint-disable-next-line @typescript-eslint/naming-convention
           info_time_ms: 0, app_time_ms: 0, user_guide_time_ms: 0,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          advanced_weather_selected_locations_count: this.advancedWeatherSelectedCount,
         })
       });
     },
@@ -3114,6 +3118,7 @@ export default defineComponent({
       this.weatherTimeMs = 0;
       this.weatherInfoTimeMs = 0;
       this.eclipseTimerTimeMs = 0;
+      this.advancedWeatherSelectedCount = 0;
       const now = Date.now();
       this.appStartTimestamp = now;
       this.infoStartTimestamp = this.showInfoSheet ? now : null;
@@ -3153,6 +3158,8 @@ export default defineComponent({
           delta_advanced_weather_time_ms: weatherTime, delta_weather_info_time_ms: weatherInfoTime,
           // eslint-disable-next-line @typescript-eslint/naming-convention
           delta_user_guide_time_ms: userGuideTime, delta_eclipse_timer_time_ms: eclipseTimerTime,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          delta_advanced_weather_selected_locations_count: this.advancedWeatherSelectedCount,
         }),
         keepalive: true,
       }).then(() => {

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -711,9 +711,11 @@
     :show-charts="showAWVChartsByDefault"
     :fullscreen="showAWVFullScreen"
     @location="(loc: LocationDeg) => {
-      locationDeg = loc;
-      updateLocationFromMap(loc);
       advancedWeatherSelectedCount += 1;
+      cloudCoverSelectedLocations.push([loc.latitudeDeg, loc.longitudeDeg]);
+    }"
+    @close="(loc: LocationDeg) => {
+      updateLocationFromMap(loc, false);
     }"
     />
   
@@ -3050,18 +3052,20 @@ export default defineComponent({
       this.wwtSettings.set_locationLng(R2D * this.location.longitudeRad);
     },
 
-    updateLocationFromMap(location: LocationDeg) {
+    updateLocationFromMap(location: LocationDeg, addToLocations=true) {
       if (location == null) {
         return;
       }
       this.locationDeg = location;
       this.updateSelectedLocationText();
 
-      const visitedLocation: [number, number] = [location.latitudeDeg, location.longitudeDeg];
-      if (this.learnerPath === "Clouds" || this.learnerPath === "CloudDetail") {
-        this.cloudCoverSelectedLocations.push(visitedLocation);
-      } else {
-        this.userSelectedLocations.push(visitedLocation);
+      if (addToLocations) {
+        const visitedLocation: [number, number] = [location.latitudeDeg, location.longitudeDeg];
+        if (this.learnerPath === "Clouds" || this.learnerPath === "CloudDetail") {
+          this.cloudCoverSelectedLocations.push(visitedLocation);
+        } else {
+          this.userSelectedLocations.push(visitedLocation);
+        }
       }
     },
 
@@ -3926,7 +3930,7 @@ export default defineComponent({
     },
 
     learnerPath(path: LearnerPath) {
-      if (!this.visitedCloudCover && (path === "Clouds") || (path === "CloudDetail")) {
+      if (!this.visitedCloudCover && ((path === "Clouds") || (path === "CloudDetail"))) {
         this.cloudCoverSelectedLocations.push([this.locationDeg.latitudeDeg, this.locationDeg.longitudeDeg]);
         this.visitedCloudCover = true;
       }

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -3938,6 +3938,7 @@ export default defineComponent({
     learnerPath(path: LearnerPath) {
       if (!this.visitedCloudCover && ((path === "Clouds") || (path === "CloudDetail"))) {
         this.cloudCoverSelectedLocations.push([this.locationDeg.latitudeDeg, this.locationDeg.longitudeDeg]);
+        this.cloudCoverSelectedCount += 1;
         this.visitedCloudCover = true;
       }
     },

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2055,6 +2055,7 @@ export default defineComponent({
       cloudCoverSelectedLocations: [] as [number, number][],
       textSearchSelectedLocations: [] as [number, number][],
       advancedWeatherSelectedCount: 0,
+      cloudCoverSelectedCount: 0,
       eclipsePrediction: null as EclipseData<Date> | null,
       eclipseStart: 0 as number | null,
       eclipseMid: 0 as number | null,
@@ -3063,6 +3064,7 @@ export default defineComponent({
         const visitedLocation: [number, number] = [location.latitudeDeg, location.longitudeDeg];
         if (this.learnerPath === "Clouds" || this.learnerPath === "CloudDetail") {
           this.cloudCoverSelectedLocations.push(visitedLocation);
+          this.cloudCoverSelectedCount += 1;
         } else {
           this.userSelectedLocations.push(visitedLocation);
         }
@@ -3109,6 +3111,8 @@ export default defineComponent({
           info_time_ms: 0, app_time_ms: 0, user_guide_time_ms: 0,
           // eslint-disable-next-line @typescript-eslint/naming-convention
           advanced_weather_selected_locations_count: this.advancedWeatherSelectedCount,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          cloud_cover_selected_locations_count: this.cloudCoverSelectedCount,
         })
       });
     },
@@ -3164,6 +3168,8 @@ export default defineComponent({
           delta_user_guide_time_ms: userGuideTime, delta_eclipse_timer_time_ms: eclipseTimerTime,
           // eslint-disable-next-line @typescript-eslint/naming-convention
           delta_advanced_weather_selected_locations_count: this.advancedWeatherSelectedCount,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          delta_cloud_cover_selected_locations_count: this.cloudCoverSelectedCount,
         }),
         keepalive: true,
       }).then(() => {

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1968,6 +1968,7 @@ export default defineComponent({
       },
 
       learnerPath: "Location" as LearnerPath,
+      visitedCloudCover: false,
       
       playing: false,
       playingIntervalId: null as ReturnType<typeof setInterval> | null,
@@ -2288,9 +2289,7 @@ export default defineComponent({
     
     selectedLocationCloudCover(): number | null {
       if (this.locationDeg) {
-        const lat = this.locationDeg.latitudeDeg;
-        const lon = this.locationDeg.longitudeDeg;
-        return this.getCloudCover(lat, lon);
+        return this.getCloudCover(this.locationDeg.latitudeDeg, this.locationDeg.longitudeDeg);
       } else {
         return null;
       }
@@ -3057,7 +3056,7 @@ export default defineComponent({
       this.updateSelectedLocationText();
 
       const visitedLocation: [number, number] = [location.latitudeDeg, location.longitudeDeg];
-      if (this.learnerPath === "Clouds") {
+      if (this.learnerPath === "Clouds" || this.learnerPath === "CloudDetail") {
         this.cloudCoverSelectedLocations.push(visitedLocation);
       } else {
         this.userSelectedLocations.push(visitedLocation);
@@ -3919,6 +3918,12 @@ export default defineComponent({
       this.updateFrontAnnotations(time);
     },
 
+    learnerPath(path: LearnerPath) {
+      if (!this.visitedCloudCover && (path === "Clouds") || (path === "CloudDetail")) {
+        this.cloudCoverSelectedLocations.push([this.locationDeg.latitudeDeg, this.locationDeg.longitudeDeg]);
+        this.visitedCloudCover = true;
+      }
+    },
 
     location(loc: LocationRad, oldLoc: LocationRad) {
       const locationDeg: [number, number] = [R2D * loc.latitudeRad, R2D * loc.longitudeRad];


### PR DESCRIPTION
This PR resolves #117:
* The first time a user switches to either of the cloud cover paths, the current location is added to the selected cloud cover locations list
* Keep track of the count of locations selected in the advanced weather view (but not the locations themselves, as they'll all end up in the cloud cover locations list)