### PR TITLE
Disable panning on mobile

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1164,7 +1164,7 @@
           :text="percentEclipsedText"
         > </v-chip>
       </div>
-      <div id="top-switches" v-if="!mobile">
+      <div id="top-switches" v-if="!showNewMobileUI">
         <div id="track-sun-switch"> 
           <hover-tooltip
               location="left"

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2186,7 +2186,7 @@ export default defineComponent({
       // @ts-ignore
       this.wwtControl.roll = function(_angle) {};
       this.wwtControl._tilt = function(_angle) {};
-      this.updatePanForMobile();
+      this.updatePanForUI();
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -2669,8 +2669,8 @@ export default defineComponent({
 
   methods: {
 
-    updatePanForMobile() {
-      if (this.mobile) {
+    updatePanForUI() {
+      if (this.showNewMobileUI) {
         this.wwtControl.move = function(_x, _y) {};
       } else {
         if (this.wwtMove) {
@@ -3880,8 +3880,8 @@ export default defineComponent({
 
   watch: {
 
-    mobile(_val: boolean) {
-      this.updatePanForMobile(); 
+    showNewMobileUI(_val: boolean) {
+      this.updatePanForUI(); 
     },
 
     showGuidedContent(_val: boolean) {


### PR DESCRIPTION
This PR disables panning on mobile by directly overwriting the `move` method of the `WWTControl` to be a no-op function. Additionally, we do the same for rolling in general - we were already disabling rolling via a watcher, but this is smoother.