### PR TITLE
Update CSS for location search

### DIFF
--- a/src/LocationSearch.vue
+++ b/src/LocationSearch.vue
@@ -1,11 +1,11 @@
 
 <template>
   <div
-    id="forward-geocoding-container"
-    :style="{...forwardGeocodingCss,...cssStyles}"
+    class="forward-geocoding-container"
+    :style="cssStyles"
   >
     <div
-      id="forward-geocoding-input-row"
+      class="forward-geocoding-input-row"
     >
       <v-text-field
         v-show="searchOpen"
@@ -24,7 +24,7 @@
         :error-messages="searchErrorMessage"
       ></v-text-field>
       <font-awesome-icon
-        id="geocoding-search-icon"
+        class="geocoding-search-icon"
         icon="magnifying-glass"
         :size="searchOpen ? 'xl' : buttonSize"
         :color="!searchOpen || (searchText && searchText.length > 2) ? accentColor : 'gray'"
@@ -40,7 +40,7 @@
       <slot name="append-icon" class="geocode-icon"></slot>
       
       <font-awesome-icon
-        id="geocoding-close-icon"
+        class="geocoding-close-icon"
         v-show="searchOpen && !stayOpen"
         icon="circle-xmark"
         :size="searchOpen ? 'xl' : '1x'"
@@ -54,7 +54,7 @@
     </div>
     
     <div
-      id="forward-geocoding-results"
+      class="forward-geocoding-results"
       :class="[small ? 'results-small' : '']"
       v-if="searchResults !== null"
     >
@@ -168,12 +168,8 @@ export default defineComponent({
       return {
         '--accent-color': this.accentColor,
         '--bg-color': 'black',
-      };
-    },
-    
-    forwardGeocodingCss() {
-      return {
-        '--fg-container-padding': this.searchOpen ? this.small ? '0px 5px 0px 0px' : '5px 10px 12px 10px' : '0px',
+        '--fg-container-padding': this.searchOpen ? (this.small ? '0px 5px 0px 0px' : '5px 10px 12px 10px') : '0px',
+        '--border-radius': this.small ? '10px' : '20px',
       };
     },
   },
@@ -244,7 +240,7 @@ export default defineComponent({
 <style lang="less" scoped>
 
 // https://vue-loader.vuejs.org/guide/scoped-css.html#deep-selectors
-#forward-geocoding-container::v-deep {
+.forward-geocoding-container::v-deep {
   --border-radius: 20px;
   position: relative;
   width: fit-content;
@@ -273,7 +269,7 @@ export default defineComponent({
     font-size: 0.8rem;
   }
 
-  #forward-geocoding-input-row {
+  .forward-geocoding-input-row {
     display: flex;
     flex-direction: row;
     justify-content: space-around;
@@ -281,36 +277,34 @@ export default defineComponent({
     align-items: center;
   }
   
-  #geocoding-search-icon {
+  .geocoding-search-icon {
     padding-inline: calc(0.3 * var(--default-line-height));
     padding-block: calc(0.4 * var(--default-line-height));
   }
 
-  #geocoding-search-icon:hover, #geocoding-close-icon:hover {
+  .geocoding-search-icon:hover, #geocoding-close-icon:hover {
     cursor: pointer;
   }
 
   // For some reason setting width: 100% makes the search results 2px too small
   // It's probably some Vuetify styling thing
   // Maybe there's a better workaround, but this gets the job done for now
-  #forward-geocoding-results {
+  .forward-geocoding-results {
     position: absolute;
     top: 42px;
     left: -1px;
     width: calc(100% + 2px);
     background: var(--bg-color);
-    border: 1px solid var(--accent-color);
+    border: 2px solid var(--accent-color);
     border-top: 0px;
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
     padding: 0px 10px;
     
     &.results-small {
-      top: 38px;
-      left:50%;
-      transform: translateX(-50%);
-      width: 95%;
-      
+      top: 34px;
+      width: calc(100% + 4px);
+      left: -2px;
     }
 
     .forward-geocoding-result {

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -791,6 +791,7 @@
             :accentColor="accentColor"
             @set-location="setLocationFromSearchFeature"
             @error="searchErrorMessage = $event"
+            small
           />
         </div>
         <div style="position:relative;">
@@ -833,7 +834,7 @@
                 locationDeg = myLocation;
                 showMyLocationDialog = false;
                 updateSelectedLocationText();
-                }"
+              }"
               @error="(error: GeolocationPositionError) => { 
                 $notify({
                   group: 'geolocation-error',
@@ -845,19 +846,19 @@
                   geolocationPermission = 'denied';
                 }
                 console.log(error);
-                }"
-                @permission="(p: PermissionState) => {
-                  geolocationPermission = p;
-                  // we're always gonna show the button,
-                  // just leaving this if we wanna change
-                  if (p == 'granted') {
-                    getMyLocation = true;
-                  } else if (p == 'prompt') {
-                    getMyLocation = true;
-                  } else {
-                    getMyLocation = true;
-                  }
-                }"
+              }"
+              @permission="(p: PermissionState) => {
+                geolocationPermission = p;
+                // we're always gonna show the button,
+                // just leaving this if we wanna change
+                if (p == 'granted') {
+                  getMyLocation = true;
+                } else if (p == 'prompt') {
+                  getMyLocation = true;
+                } else {
+                  getMyLocation = true;
+                }
+              }"
             ></geolocation-button>
           </div>
         </div>

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -786,6 +786,7 @@
       <div id="left-buttons-wrapper" :class="[!showGuidedContent ?'budge' : '']">
         <div id='geocoding-row' class="d-flex align-center ga-1">
           <location-search
+            class="location-search-overwwt"
             v-model="searchOpen"
             :search-provider="geocodingInfoForSearch"
             :accentColor="accentColor"
@@ -794,7 +795,7 @@
             small
           />
         </div>
-        <div style="position:relative;">
+        <div>
           <icon-button
             v-if="getMyLocation"
             class="geolocation-button"
@@ -4237,6 +4238,10 @@ body {
   #my-location-button {
     border-width: 2px;
   }
+
+  .location-search-overwwt {
+    z-index: 600;
+  }
 }
 
 #app {
@@ -5391,7 +5396,7 @@ video, #info-video {
       
       backdrop-filter: blur(5px) saturate(50%);
     }
-    
+
     .location-search-overmap {
       height: fit-content;
       position: absolute;
@@ -5408,7 +5413,7 @@ video, #info-video {
         right: 4em;
       }
     }
-    
+
     #eclipse-details-overmap-button {
       height: fit-content;
       position: absolute;

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -238,7 +238,7 @@
               >
               <span v-if="showEclipsePredictionText">
                 {{ eclipsePredictionText }}
-                <v-icon v-if="$vuetify.display.width<600" style="padding: 2px; border-radius:3px; background-color:#ddd;" class="elevation-2" @click="showEclipsePredictionSheet = true; showEclipsePredictionText = true">mdi-sun-clock</v-icon> 
+                <v-icon v-if="narrow" style="padding: 2px; border-radius:3px; background-color:#ddd;" class="elevation-2" @click="showEclipsePredictionSheet = true; showEclipsePredictionText = true">mdi-sun-clock</v-icon> 
               </span>
               <span v-else>
                 {{ touchscreen ? "Tap" : "Click" }} <v-icon style="padding: 2px; border-radius:3px; background-color:#ddd;" class="elevation-2" @click="showEclipsePredictionSheet = true; showEclipsePredictionText = true">mdi-sun-clock</v-icon> to see eclipse predictions
@@ -252,7 +252,7 @@
             <location-search
               :modelValue="false"
               :class="['location-search-overmap', learnerPath === 'Clouds' ? 'overmap-budge' : '', showNewMobileUI ? '' : 'overmap-low']"
-              v-if="$vuetify.display.width <= 600"
+              v-if="narrow"
               small
               buttonSize="xl"
               :search-provider="geocodingInfoForSearch"
@@ -262,7 +262,7 @@
             >
             </location-search>
             <icon-button
-              v-if="$vuetify.display.width <= 600"
+              v-if="narrow"
               id="eclipse-details-overmap"
               md-icon="sun-clock"
               md-size="24"
@@ -938,7 +938,7 @@
           </div>
         </div>
 
-        <div v-if="mobile">
+        <div v-if="narrow">
           <p class="splash-small-text">
             <a 
               href="#" 
@@ -946,7 +946,7 @@
           </p>
         </div>
         
-        <div v-if="mobile && showNewMobileUI" id="splash-screen-guide" class="mb-7">
+        <div v-if="showNewMobileUI" id="splash-screen-guide" class="mb-7">
           <v-row>
             <v-col cols="12">
               <v-icon icon="mdi-creation" size="small" class="bullet-icon"></v-icon>
@@ -967,7 +967,7 @@
           </v-row>
         </div>
 
-        <div v-if="!mobile || !showNewMobileUI " id="splash-screen-guide">
+        <div v-if="!showNewMobileUI " id="splash-screen-guide">
         <!-- <div v-if="false" id="splash-screen-guide"> -->
           <v-row>
             <v-col cols="12">
@@ -1289,7 +1289,7 @@
               hide-details 
             />  
             <v-checkbox
-              v-show="mobile"
+              v-show="narrow"
               v-model="showNewMobileUI"
               label="New Interface"
               :color="accentColor"
@@ -2137,7 +2137,7 @@ export default defineComponent({
       this.updateSelectedLocationText();
     }
     
-    this.showNewMobileUI = this.mobile;
+    this.showNewMobileUI = this.narrow;
         
     if (!this.showSplashScreen) {
       this.showEclipsePredictionTextBanner = !this.showNewMobileUI;
@@ -2434,6 +2434,9 @@ export default defineComponent({
     },
     xSmallSize(): boolean {
       return this.$vuetify.display.xs;
+    },
+    narrow(): boolean {
+      return this.$vuetify.display.width <= 600;
     },
     
     mobile(): boolean {


### PR DESCRIPTION
This PR updates some CSS for the location search to better deal with the `small` option, and to make sure that the search box is above the geolocation button and the location/time/% eclipsed chips. This is built off of the first commit in #126.