### PR TITLE
Allow searching for a location by ZIP code

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -3834,7 +3834,7 @@ export default defineComponent({
 
     async geocodingInfoForSearch(searchText: string): Promise<MapBoxFeatureCollection | null> {
       const accessToken = process.env.VUE_APP_MAPBOX_ACCESS_TOKEN;
-      const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${searchText}.json?access_token=${accessToken}&types=place`;
+      const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${searchText}.json?access_token=${accessToken}&types=place,postcode`;
       return fetch(url)
         .then(response => response.json())
         .then((result: MapBoxFeatureCollection) => {


### PR DESCRIPTION
This PR updates the MapBox request that we send to allow searching by postcode. This means that users can now search for their location in the story using their ZIP code.