### PR TITLE
A short timeout for closing the location search

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -3990,7 +3990,9 @@ export default defineComponent({
     setLocationFromSearchFeature(feature: MapBoxFeature) {
       this.setLocationFromFeature(feature);
       this.textSearchSelectedLocations.push(feature.center);
-      this.searchOpen = false;
+      setTimeout(() => {
+        this.searchOpen = false;
+      }, 3_000);
     },
     
     reversePlaybackRate() {


### PR DESCRIPTION
This adds a short time out before closing the location search after a successful search so the user can see "Location Updated"

