### PR TITLE
Pause when overlay is open

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2294,7 +2294,7 @@ export default defineComponent({
   },
 
   mounted() {  
-
+    console.log(this.$vuetify);
     if (queryData.latitudeDeg !== undefined && queryData.longitudeDeg !== undefined) {
       this.selectedTimezone = tzlookup(...[queryData.latitudeDeg, queryData.longitudeDeg]);
       this.updateSelectedLocationText();
@@ -2844,9 +2844,6 @@ export default defineComponent({
   methods: {
     
     pauseForOverlay() {
-      if (!this.showNewMobileUI) {
-        return;
-      }
       const increment = this.playing  || this.playingWaitCount > 0;
       this.playingWaitCount = increment ? this.playingWaitCount + 1 : 0;
       this.playing = false;
@@ -2854,9 +2851,6 @@ export default defineComponent({
     },
     
     playForOverlay() {
-      if (!this.showNewMobileUI) {
-        return;
-      }
       if (this.playingWaitCount === 1) {
         this.playing = true;
       } 

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2842,6 +2842,22 @@ export default defineComponent({
   },
 
   methods: {
+    
+    pauseForOverlay() {
+      const increment = this.playing  || this.playingWaitCount > 0;
+      this.playingWaitCount = increment ? this.playingWaitCount + 1 : 0;
+      this.playing = false;
+      
+    },
+    
+    playForOverlay() {
+      if (this.playingWaitCount === 1) {
+        this.playing = true;
+      } 
+      
+      this.playingWaitCount = this.playingWaitCount === 0 ? 0 : this.playingWaitCount - 1;
+
+    },
 
     updatePanForMobile() {
       if (this.showNewMobileUI) {
@@ -4063,12 +4079,17 @@ export default defineComponent({
         this.onScroll();
       });
       if (show) {
+        if (this.narrow) {
+          this.pauseForOverlay();
+        }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (this.$refs.showGuidedContent as any).tooltip = false;
         const element = document.activeElement;
         if (element && element.id === "show-guided-content-button") {
           (element as HTMLElement).blur();
         }
+      } else if (this.narrow) {
+        this.playForOverlay();
       }
     },
     
@@ -4216,47 +4237,79 @@ export default defineComponent({
       // Keep track of how long the user has the book open/closed
       if (show) {
         this.infoStartTimestamp = Date.now();
+        this.pauseForOverlay();
       } else if (this.infoStartTimestamp !== null) {
         this.infoTimeMs += (Date.now() - this.infoStartTimestamp);
         this.infoStartTimestamp = null;
       }
+      
+      if (!show) {
+        this.playForOverlay();
+      }
+      
     },
 
     showAdvancedWeather(show: boolean) {
       if (show) {
         this.weatherStartTimestamp = Date.now();
-        this.playing = false;
+        this.pauseForOverlay();
       } else if (this.weatherStartTimestamp !== null) {
         this.weatherTimeMs += (Date.now() - this.weatherStartTimestamp);
         this.weatherStartTimestamp = null;
+      }
+      
+      if (!show) {
+        this.playForOverlay();
       }
     },
 
     showWWTGuideSheet(show: boolean) {
       if (show) {
         this.userGuideStartTimestamp = Date.now();
+        
       } else if (this.userGuideStartTimestamp !== null) {
         this.userGuideTimeMs += (Date.now() - this.userGuideStartTimestamp);
         this.userGuideStartTimestamp = null;
+      }
+      
+      if (!show && this.narrow) {
+        this.playForOverlay();
       }
     },
 
     showEclipsePredictionSheet(show: boolean) {
       if (show) {
-        this.playing = false;
+        this.pauseForOverlay();
         this.eclipseTimerStartTimestamp = Date.now();
       } else if (this.eclipseTimerStartTimestamp !== null) {
         this.eclipseTimerTimeMs += (Date.now() - this.eclipseTimerStartTimestamp);
         this.eclipseTimerStartTimestamp = null;
+      }
+      
+      if (!show) {
+        this.playForOverlay();
       }
     },
 
     weatherInfoOpen(open: boolean) {
       if (open) {
         this.weatherInfoStartTimestamp = Date.now();
+        this.pauseForOverlay();
       } else if (this.weatherInfoStartTimestamp !== null) {
         this.weatherInfoTimeMs += (Date.now() - this.weatherInfoStartTimestamp);
         this.weatherInfoStartTimestamp = null;
+      }
+      
+      if (!open) {
+        this.playForOverlay();
+      }
+    },
+    
+    showPrivacyDialog(show: boolean) {
+      if (show) {
+        this.pauseForOverlay();
+      } else {
+        this.playForOverlay();
       }
     },
     

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -5495,7 +5495,7 @@ video, #info-video {
   display: flex;
   flex-direction: row;
   
-  @media (max-width: 600px) and (max-aspect-ratio: 1) {
+  @media (max-width: 600px) {
     flex-direction: column;
     gap: 1rem;
   }
@@ -5516,7 +5516,7 @@ video, #info-video {
 
   #non-map-container {
     flex-basis: 100%;
-    @media (max-width: 600px) and (max-aspect-ratio: 1) {
+    @media (max-width: 600px) {
       flex-basis: fit-content;
     }
   }

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2294,7 +2294,7 @@ export default defineComponent({
   },
 
   mounted() {  
-    console.log(this.$vuetify);
+
     if (queryData.latitudeDeg !== undefined && queryData.longitudeDeg !== undefined) {
       this.selectedTimezone = tzlookup(...[queryData.latitudeDeg, queryData.longitudeDeg]);
       this.updateSelectedLocationText();

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2844,6 +2844,9 @@ export default defineComponent({
   methods: {
     
     pauseForOverlay() {
+      if (!this.showNewMobileUI) {
+        return;
+      }
       const increment = this.playing  || this.playingWaitCount > 0;
       this.playingWaitCount = increment ? this.playingWaitCount + 1 : 0;
       this.playing = false;
@@ -2851,6 +2854,9 @@ export default defineComponent({
     },
     
     playForOverlay() {
+      if (!this.showNewMobileUI) {
+        return;
+      }
       if (this.playingWaitCount === 1) {
         this.playing = true;
       } 

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2845,13 +2845,14 @@ export default defineComponent({
     
     pauseForOverlay() {
       const increment = this.playing  || this.playingWaitCount > 0;
-      this.playingWaitCount = increment ? this.playingWaitCount + 1 : 0;
+      this.playingWaitCount = increment ? this.playingWaitCount + 1 : this.playingWaitCount;
       this.playing = false;
       
     },
     
     playForOverlay() {
       if (this.playingWaitCount === 1) {
+        console.log('playForOverlay');
         this.playing = true;
       } 
       
@@ -4069,6 +4070,10 @@ export default defineComponent({
 
   watch: {
 
+    playingWaitCount(val: number, old: number) {
+      console.log(`Playing wait count: ${old} ---> ${val}`);
+    },
+    
     showNewMobileUI(_val: boolean) {
       this.updatePanForMobile(); 
     },

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -4266,13 +4266,13 @@ export default defineComponent({
     showWWTGuideSheet(show: boolean) {
       if (show) {
         this.userGuideStartTimestamp = Date.now();
-        
+        this.pauseForOverlay();
       } else if (this.userGuideStartTimestamp !== null) {
         this.userGuideTimeMs += (Date.now() - this.userGuideStartTimestamp);
         this.userGuideStartTimestamp = null;
       }
       
-      if (!show && this.narrow) {
+      if (!show) {
         this.playForOverlay();
       }
     },


### PR DESCRIPTION
This PR pauses the display whenever one of the overlays is opened (the guided content on narrow, the user guide, the info sheet, the eclipse timer, the advanced weather view and the weather info box). if it was already paused it does nothing, otherwise it keeps track of how many times it was triggered and then only unpauses once the final dialog is closed. 
