### PR TITLE
Reset forecast info start timestamp

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -3446,6 +3446,7 @@ export default defineComponent({
       this.weatherStartTimestamp = this.showAdvancedWeather ? now : null;
       this.weatherInfoStartTimestamp = this.weatherInfoOpen ? now : null;
       this.eclipseTimerStartTimestamp = this.showEclipsePredictionSheet ? now : null;
+      this.forecastInfoStartTimestamp = this.showForecastSheet ? now : null;
     },
 
     sendUpdateData() {


### PR DESCRIPTION
This PR fixes an issue with the forecast info timestamp not being reset. (This was supposed to be in #152 but I forgot to push my local commit).