### PR TITLE
Add button to change app time to system time

### DIFF
--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1075,14 +1075,16 @@
 
         <div>
           <v-btn
-          class="splash-get-started"
-          @click="closeSplashScreen"
-          :color="accentColor"
-          :density="xSmallSize ? 'compact' : 'default'"
-          size="x-large"
-          variant="elevated"
-          rounded="lg"
-          >Get Started</v-btn>
+            class="splash-get-started"
+            @click="closeSplashScreen"
+            :color="accentColor"
+            :density="xSmallSize ? 'compact' : 'default'"
+            size="x-large"
+            variant="elevated"
+            rounded="lg"
+          >
+            Get Started
+          </v-btn>
         </div>
 
         <div v-if="narrow">
@@ -1532,6 +1534,12 @@
       <div id="tools">
         <span class="tool-container">
           <div style="position: relative">
+            <v-btn
+              :disabled="nowOutsideTimeRange"
+              @click="selectedTime = Math.max(minTime, Math.min(maxTime, Date.now()))"
+            >
+              Now
+            </v-btn>
             <div id="speed-control">
               <icon-button
                 id="reverse-speed"
@@ -2245,10 +2253,11 @@ export default defineComponent({
       
       toggleTrackSun: true,
       
-      times: times, 
-      minTime: minTime,
-      maxTime: maxTime,
+      times,
+      minTime,
+      maxTime,
       millisecondsPerInterval: MILLISECONDS_PER_INTERVAL,
+      nowOutsideTimeRange: false,
       
       accentColor: "#eac402",
       moonColor: "#CFD8DC",
@@ -2340,6 +2349,10 @@ export default defineComponent({
   },
 
   mounted() {  
+
+    setInterval(() => {
+      this.nowOutsideTimeRange = Date.now() < this.minTime || Date.now() > this.maxTime;
+    }, 1000);
 
     if (queryData.latitudeDeg !== undefined && queryData.longitudeDeg !== undefined) {
       this.selectedTimezone = tzlookup(...[queryData.latitudeDeg, queryData.longitudeDeg]);
@@ -2885,6 +2898,7 @@ export default defineComponent({
         this.showNewMobileUI = !value;
       },
     },
+
   },
 
   methods: {
@@ -4208,7 +4222,7 @@ export default defineComponent({
     
     nearTotality(near: boolean, oldNear: boolean) {
       if (near) {
-        this.forceRate =  (Math.abs(this.playbackRate) > 10) && this.playing;
+        this.forceRate = (Math.abs(this.playbackRate) > 10) && this.playing;
       }
       
       // if leaving eclipse reset speed to previous

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -897,7 +897,9 @@
                 };
                 locationDeg = myLocation;
                 showMyLocationDialog = false;
-                updateSelectedLocationText();
+                $nextTick(() => {
+                  updateSelectedLocationText();
+                });
               }"
               @error="(error: GeolocationPositionError) => { 
                 $notify({

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1510,6 +1510,20 @@
       </div>
       
       <div id="eclipse-percent-chip">
+        <v-btn
+          id="set-time-now-button"
+          variant="outlined"
+          rounded="xl"
+          :disabled="nowOutsideTimeRange"
+          :color="nowOutsideTimeRange ? 'gray' : '#eac402'"
+          @click="() => {
+            selectedTime = Math.max(minTime, Math.min(maxTime, Date.now()));
+            playbackRate=1;
+            playing=true;
+            }"
+        >
+          Now
+        </v-btn>
         <v-chip 
           v-if="!showNewMobileUI"
           :prepend-icon="smallSize ? `` : `mdi-sun-angle`"
@@ -1534,16 +1548,6 @@
       <div id="tools">
         <span class="tool-container">
           <div style="position: relative">
-            <v-btn
-              :disabled="nowOutsideTimeRange"
-              @click="() => {
-                selectedTime = Math.max(minTime, Math.min(maxTime, Date.now()));
-                playbackRate=1;
-                playing=true;
-                }"
-            >
-              Now
-            </v-btn>
             <div id="speed-control">
               <icon-button
                 id="reverse-speed"
@@ -1589,28 +1593,6 @@
                 faSize="1x"
                 :show-tooltip="!mobile"
               ></icon-button>
-              <icon-button
-              v-if="false"
-              id="set-time-now-button"
-              @activate="() => {
-                // selectedTime = times.reduce((a, b) => {
-                //   return Math.abs(b - Date.now()) < Math.abs(a - Date.now()) ? b : a;
-                // });
-                selectedTime = Date.now();
-                playbackRate=1;
-                playing = true;
-                console.log('to now')
-              }"
-              :color="accentColor"
-              tooltip-text="Go to current time"
-              tooltip-location="top"
-              tooltip-offset="5px"
-              :show-tooltip="!mobile"
-            >
-              <template v-slot:button>
-                Now
-              </template>
-            </icon-button>
               <icon-button
                 id="reset"
                 :fa-icon="'rotate'"
@@ -4851,6 +4833,16 @@ body {
   }
 }
 
+#set-time-now-button {
+  // position: absolute;
+  // bottom: 15%;
+  // left: 5%;
+  margin-left: 3%;
+  background-color: black !important;
+  pointer-events: auto;
+  border: solid 2px;
+}
+
 .tool-container {
   display: flex;
   width: 99%;
@@ -6242,8 +6234,8 @@ video, #info-video {
   // right: 0.5rem;
   // top: calc(-1.5 * var(--default-line-height));
     display: flex;
-    flex-direction: column;
-    gap: 0.5em;
+    width: 100%;
+    justify-content: space-between;
 
   .v-chip.v-chip--density-default {
     height: var(--default-line-height);

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1536,7 +1536,11 @@
           <div style="position: relative">
             <v-btn
               :disabled="nowOutsideTimeRange"
-              @click="selectedTime = Math.max(minTime, Math.min(maxTime, Date.now()))"
+              @click="() => {
+                selectedTime = Math.max(minTime, Math.min(maxTime, Date.now()));
+                playbackRate=1;
+                playing=true;
+                }"
             >
               Now
             </v-btn>

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -2073,7 +2073,7 @@ export default defineComponent({
     },
   },
   data() {
-    const _totalEclipseTimeUTC = new Date("2024-04-08T18:18:00Z");
+    const totalEclipseTimeUTC = new Date("2024-04-08T18:18:00Z");
 
     const sunPlace = new Place();
     sunPlace.set_names(["Sun"]);
@@ -2182,7 +2182,7 @@ export default defineComponent({
       pointerStartPosition: null as { x: number; y: number } | null,  
 
       // "Greatest Eclipse"
-      selectedTime:  _totalEclipseTimeUTC.getTime() - 60*60*1000*1.5,
+      selectedTime:  totalEclipseTimeUTC.getTime() - 60*60*1000*1.5,
       selectedTimezone: "America/Mexico_City",
       location,
       selectedLocationText: "Nazas, Mexico",

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -895,10 +895,10 @@
                   latitudeDeg: loc.latitude, 
                   longitudeDeg: loc.longitude
                 };
-                locationDeg = myLocation;
                 showMyLocationDialog = false;
                 
                 if (myLocation.latitudeDeg !== locationDeg.latitudeDeg || myLocation.longitudeDeg !== locationDeg.longitudeDeg) {
+                  locationDeg = myLocation;
                   $nextTick(() => {
                     updateSelectedLocationText();
                   });

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -1096,7 +1096,7 @@
         </div>
         <div v-else>
           <p class="splash-small-text">
-            <v-icon icon="mdi-creation" size="small" class="bullet-icon"></v-icon> New! April 8 weather forecast
+            <v-icon icon="mdi-creation" size="small" class="bullet-icon"></v-icon> New! NOW button, active starting at 6:40am EDT
           </p>
         </div>
 
@@ -1160,7 +1160,7 @@
         <div class="inst-quad bottom-left">
           <div class="inst-arrow"><v-icon  class="the-arrow" :color="accentColor" :size="Math.min($vuetify.display.width*0.16,$vuetify.display.height*0.16)">mdi-arrow-up-bold</v-icon></div>
           <div class="inst-text">
-            Control or "slide" time yourself!
+            New! Set time to "Now," or control time yourself!
           </div>
         </div>
         <div class="inst-quad bottom-right">


### PR DESCRIPTION
This PR adds a button that changes the app time to the system time, clamped to be within our min and max time values on the slider. Currently I've set the button to be disabled when the current time is outside of that range.

Since the system time isn't reactive, I've set a function to run on a 1-second interval that checks whether the system time is inside of the range. Also, while WWT has a function for resetting to the current system time, we would also need to update the app time, which triggers a WWT time update. Thus there's really no benefit - we can just update the app time and let the watcher update WWT.

Marking as a draft so that we can set up styling.