### PR TITLE
Reduce number of MapBox requests

### DIFF
--- a/src/AdvancedWeatherView.vue
+++ b/src/AdvancedWeatherView.vue
@@ -1230,10 +1230,17 @@ export default defineComponent({
         this.firstOpen = false;
         // this.displayData = false;
       }
+
+      if (value && (this.defaultLocation.latitudeDeg !== this.location.latitudeDeg || this.defaultLocation.longitudeDeg !== this.location.longitudeDeg)) {
+        this.location = this.defaultLocation;
+      }
     }, 
     
     defaultLocation(value: CityLocation) {
       console.log('defaultLocation', value);
+      if (!this.modelValue) {
+        return;
+      }
       // check if they are the same, if so do nothing
       if (value.latitudeDeg === this.location.latitudeDeg && value.longitudeDeg === this.location.longitudeDeg) {
         return;
@@ -1273,8 +1280,10 @@ export default defineComponent({
     },
     
     location(value: CityLocation, old: CityLocation) {
-      console.log('location', value);
       if (value.latitudeDeg === old.latitudeDeg && value.longitudeDeg === old.longitudeDeg) {
+        return;
+      }
+      if (!this.modelValue) {
         return;
       }
       if (

--- a/src/SolarEclipse2024.vue
+++ b/src/SolarEclipse2024.vue
@@ -897,7 +897,9 @@
                 };
                 locationDeg = myLocation;
                 showMyLocationDialog = false;
-                updateSelectedLocationText();
+                if (myLocation.latitudeDeg !== locationDeg.latitudeDeg || myLocation.longitudeDeg !== locationDeg.longitudeDeg) {
+                  updateSelectedLocationText();
+                }
               }"
               @error="(error: GeolocationPositionError) => { 
                 $notify({


### PR DESCRIPTION
I noticed that, currently, we make two MapBox requests every time we change our location. After looking into this, it turns out that the reason is that the AWV makes its own request to update its location name info. This PR attempts to cut down on the number of requests by only having the AWV make a request to update its location name when it's open (and then make a request when it's opened to get it back up-to-date). There may be a few more places that we can trim down on requests, but I think this should get rid of the lion's share of duplication.