### PR TITLE
Set icons for mobile browser shortcuts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,8 +32,11 @@
   <meta name="twitter:creator" content="@CosmicDataStory">
   <meta name="twitter:image" content="https://projects.cosmicds.cfa.harvard.edu/solar-eclipse-2024/preview.png">
   <link rel="icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.png">
-  <link rel="apple-touch-icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.png">
-  <link rel="shortcut icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.png">
+  <link rel="apple-touch-icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-57.png">
+  <link rel="apple-touch-icon" sizes="72x72" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-72.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-114.png">
+  <link rel="apple-touch-icon" sizes="144x144" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-144.png">
+  <link rel="shortcut icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.ico">
   <title>Cosmic Data Stories: Solar Eclipse 2024</title>
 </head>
 

--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,7 @@
   <meta name="twitter:creator" content="@CosmicDataStory">
   <meta name="twitter:image" content="https://projects.cosmicds.cfa.harvard.edu/solar-eclipse-2024/preview.png">
   <link rel="icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.png">
+  <link rel="apple-touch-icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.png">
   <title>Cosmic Data Stories: Solar Eclipse 2024</title>
 </head>
 

--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,7 @@
   <meta name="twitter:image" content="https://projects.cosmicds.cfa.harvard.edu/solar-eclipse-2024/preview.png">
   <link rel="icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.png">
   <link rel="apple-touch-icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.png">
+  <link rel="shortcut icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.png">
   <title>Cosmic Data Stories: Solar Eclipse 2024</title>
 </head>
 

--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,7 @@
   <link rel="apple-touch-icon" sizes="114x114" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-114.png">
   <link rel="apple-touch-icon" sizes="144x144" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon-144.png">
   <link rel="shortcut icon" href="https://projects.cosmicds.cfa.harvard.edu/cds-website/cosmicds-favicon.ico">
+  <link rel="manifest" href="site.webmanifest">
   <title>Cosmic Data Stories: Solar Eclipse 2024</title>
 </head>
 

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,3 @@
+{
+  "name": "Cosmic Data Stories: Solar Eclipse 2024"
+}


### PR DESCRIPTION
This PR adds some `link` tags to our index file that sets the icons when a user creates a shortcut to the page on iOS/Android. iOS uses the [`apple-touch-icon` links](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html), whereas Android uses the `icon` link and apparently [needs a site manifest](https://stackoverflow.com/questions/78016974/include-icon-when-add-to-home-screen-from-android-chrome)