### PR TITLE
Use NASA Grantee logo

### DIFF
--- a/src/CreditLogos.vue
+++ b/src/CreditLogos.vue
@@ -11,7 +11,7 @@
         ><img alt="SciAct Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/logo_sciact.png"
       /></a>
       <a href="https://nasa.gov/" target="_blank" rel="noopener noreferrer" class="pl-1"
-        ><img alt="SciAct Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/NASA_Partner_color_300_no_outline.png"
+        ><img alt="SciAct Logo" src="https://projects.cosmicds.cfa.harvard.edu/cds-website/logos/NASA_Grantee_color_no_outline.png"
       /></a>
     </div>
   </div>

--- a/src/GeolocationButton.vue
+++ b/src/GeolocationButton.vue
@@ -55,7 +55,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { VBtn } from 'vuetify/components/VBtn';
-import { VProgressCircular } from 'vuetify/lib/components/index.mjs';
+import { VProgressCircular } from 'vuetify/components';
 
 type Density = null | 'default' | 'comfortable' | 'compact';
 


### PR DESCRIPTION
This PR updates the local credit logos component to use the NASA Grantee logo. It also updates the import for the Vuetify circular progress component.